### PR TITLE
Add flag argument separator.

### DIFF
--- a/src/CommandLine.Abstractions/BuilderSettings.cs
+++ b/src/CommandLine.Abstractions/BuilderSettings.cs
@@ -54,6 +54,9 @@ public sealed class BuilderSettings : IEngineSettings
 
 	/// <inheritdoc/>
 	public TimeSpan ExecutionTimeout { get; set; } = TimeSpan.Zero;
+
+	/// <inheritdoc/>
+	public string FlagArgumentSeparator { get; set; } = "--";
 	#endregion
 
 	#region Methods
@@ -207,6 +210,18 @@ public sealed class BuilderSettings : IEngineSettings
 		duration.ThrowIfLessThan(TimeSpan.Zero, nameof(duration));
 
 		ExecutionTimeout = duration;
+		return this;
+	}
+
+	/// <summary>Sets the <see cref="FlagArgumentSeparator"/> setting.</summary>
+	/// <param name="separator">The separator to use when marking the end of flags, where everything aftwards will be parsed as arguments.</param>
+	/// <returns>The used builder instance.</returns>
+	/// <exception cref="ArgumentException">Thrown if the given <paramref name="separator"/> is empty or only consists of white-space characters.</exception>
+	public BuilderSettings WithFlagArgumentSeparator(string separator)
+	{
+		separator.ThrowIfEmptyOrWhitespace(nameof(separator));
+
+		FlagArgumentSeparator = separator;
 		return this;
 	}
 	#endregion

--- a/src/CommandLine.Abstractions/IEngineSettings.cs
+++ b/src/CommandLine.Abstractions/IEngineSettings.cs
@@ -76,5 +76,8 @@ public interface IEngineSettings
 	/// <summary>The maximum amount of time a command can take to execute, use <see cref="TimeSpan.Zero"/> for an infinite amount of time.</summary>
 	/// <remarks>Once the actual command is being executed, this value is merely a suggestion that the command itself needs to respect.</remarks>
 	TimeSpan ExecutionTimeout { get; }
+
+	/// <summary>The separator used to mark the end of flags, where everything after it is going to be parsed as arguments.</summary>
+	string FlagArgumentSeparator { get; }
 	#endregion
 }

--- a/src/CommandLine/EngineSettings.cs
+++ b/src/CommandLine/EngineSettings.cs
@@ -53,6 +53,9 @@ public sealed class EngineSettings : IEngineSettings
 
 	/// <inheritdoc/>
 	public required TimeSpan ValidationTimeout { get; init; }
+
+	/// <inheritdoc/>
+	public required string FlagArgumentSeparator { get; init; }
 	#endregion
 
 	#region Functions
@@ -91,6 +94,7 @@ public sealed class EngineSettings : IEngineSettings
 			ShortFlagPrefix = settings.ShortFlagPrefix,
 			FlagValueSeparators = [.. settings.FlagValueSeparators.OrderByDescending(s => s.Length)],
 			MergeLongAndShortFlags = settings.MergeLongAndShortFlags,
+			FlagArgumentSeparator = settings.FlagArgumentSeparator,
 
 			IncludeHelpFlag = settings.IncludeHelpFlag,
 			LongHelpFlagName = settings.LongHelpFlagName,


### PR DESCRIPTION
This PR adds the flag argument separator (used for marking the end of flags, and that everything afterwards should be parsed as arguments), as per issue #2.