### PR TITLE
Implement network type parsers.

### DIFF
--- a/src/CommandLine.Abstractions/SpecialTypes/Port.cs
+++ b/src/CommandLine.Abstractions/SpecialTypes/Port.cs
@@ -1,0 +1,228 @@
+namespace OwlDomain.CommandLine.SpecialTypes;
+
+/// <summary>
+/// 	Represents a networking port.
+/// </summary>
+/// <param name="number">The port number.</param>
+[DebuggerDisplay($"{{{nameof(DebuggerDisplay)}(), nq}}")]
+public readonly struct Port(ushort number) :
+#if NET7_0_OR_GREATER
+	IParsable<Port>,
+	ISpanParsable<Port>,
+	IEqualityOperators<Port, Port, bool>,
+	IComparisonOperators<Port, Port, bool>,
+#endif
+	IEquatable<Port>,
+	IComparable<Port>
+{
+	#region Nested types
+	private readonly struct Pair(ushort number, string name)
+	{
+		#region Fields
+		public readonly ushort Number = number;
+		public readonly string Name = name;
+		#endregion
+	}
+	#endregion
+
+	#region Fields
+	private static readonly Pair[] KnownPairs =
+	[
+		new(7, "echo"),
+		new(17, "qotd"),
+		new(22, "ssh"),
+		new(23, "telnet"),
+		new(25, "smtp"),
+		new(37, "time"),
+		new(43, "whois"),
+		new(53, "dns"),
+		new(70, "gopher"),
+		new(80, "http"),
+		new(123, "ntp"),
+		new(194, "irc"),
+		new(220, "imap"),
+		new(443, "https"),
+		new(530, "rpc"),
+	];
+	#endregion
+
+	#region Properties
+	/// <summary>The number of the port.</summary>
+	public readonly ushort Number { get; } = number;
+
+	/// <summary>The name of the port.</summary>
+	public readonly string? Name => TryGetName(Number, out string? name) ? name : null;
+	#endregion
+
+	#region Methods
+	/// <inheritdoc/>
+	public int CompareTo(Port other) => Number.CompareTo(other.Number);
+
+	/// <inheritdoc/>
+	public bool Equals(Port other) => Number.Equals(other.Number);
+
+	/// <inheritdoc/>
+	public override bool Equals([NotNullWhen(true)] object? obj)
+	{
+		if (obj is Port other)
+			return Equals(other);
+
+		return false;
+	}
+
+	/// <inheritdoc/>
+	public override int GetHashCode() => Number.GetHashCode();
+
+	/// <inheritdoc/>
+	public override string ToString() => Number.ToString();
+	#endregion
+
+	#region Functions
+	/// <summary>Parses the given <paramref name="text"/> into a <see cref="Port"/> value.</summary>
+	/// <param name="text">The text to parse.</param>
+	/// <param name="provider">An object that provides culture-specific formatting about <paramref name="text"/>.</param>
+	/// <returns>The parsed port value.</returns>
+	/// <exception cref="FormatException">Thrown if the given <paramref name="text"/> <see langword="string"/> was not in the correct format.</exception>
+	public static Port Parse(ReadOnlySpan<char> text, IFormatProvider? provider)
+	{
+		if (TryParse(text, provider, out Port result))
+			return result;
+
+		throw new FormatException($"Couldn't parse '{text.ToString()}' as a valid port number.");
+	}
+
+	/// <summary>Parses the given <paramref name="text"/> into a <see cref="Port"/> value.</summary>
+	/// <param name="text">The text to parse.</param>
+	/// <param name="provider">An object that provides culture-specific formatting about <paramref name="text"/>.</param>
+	/// <returns>The parsed port value.</returns>
+	/// <exception cref="ArgumentNullException">Thrown if the given <paramref name="text"/> is <see langword="null"/>.</exception>
+	/// <exception cref="FormatException">Thrown if the given <paramref name="text"/> <see langword="string"/> was not in the correct format.</exception>
+	public static Port Parse(string text, IFormatProvider? provider)
+	{
+		if (TryParse(text.AsSpan(), provider, out Port result))
+			return result;
+
+		throw new FormatException($"Couldn't parse '{text}' as a valid port number.");
+	}
+
+	/// <summary>Tries to parse the given <paramref name="text"/> into a <see cref="Port"/> value.</summary>
+	/// <param name="text">The text to parse.</param>
+	/// <param name="provider">An object that provides culture-specific formatting about <paramref name="text"/>.</param>
+	/// <param name="result">The parsed port value.</param>
+	/// <returns><see langword="true"/> if the given <paramref name="text"/> was parsed correctly, <see langword="false"/> otherwise.</returns>
+	public static bool TryParse(ReadOnlySpan<char> text, IFormatProvider? provider, [MaybeNullWhen(false)] out Port result)
+	{
+		if (ushort.TryParse(text, out ushort number))
+		{
+			result = number;
+			return true;
+		}
+
+		foreach (Pair pair in KnownPairs)
+		{
+			if (text.Equals(pair.Name, StringComparison.OrdinalIgnoreCase))
+			{
+				result = pair.Number;
+				return true;
+			}
+		}
+
+		result = default;
+		return false;
+	}
+
+	/// <summary>Tries to parse the given <paramref name="text"/> into a <see cref="Port"/> value.</summary>
+	/// <param name="text">The text to parse.</param>
+	/// <param name="provider">An object that provides culture-specific formatting about <paramref name="text"/>.</param>
+	/// <param name="result">The parsed port value.</param>
+	/// <returns><see langword="true"/> if the given <paramref name="text"/> was parsed correctly, <see langword="false"/> otherwise.</returns>
+	public static bool TryParse([NotNullWhen(true)] string? text, IFormatProvider? provider, [MaybeNullWhen(false)] out Port result)
+	{
+		if (text is null)
+		{
+			result = default;
+			return false;
+		}
+
+		return TryParse(text.AsSpan(), provider, out result);
+	}
+	#endregion
+
+	#region Helpers
+	[ExcludeFromCodeCoverage]
+	private string DebuggerDisplay()
+	{
+		const string typeName = nameof(Port);
+		const string numberName = nameof(Number);
+		const string nameName = nameof(Name);
+		string? name = Name;
+
+		if (name is not null)
+			return $"{typeName} {{ {numberName} = ({Number:n0}), {nameName} = ({name}) }}";
+
+		return $"{typeName} {{ {numberName} = ({Number:n0}) }}";
+	}
+	private static bool TryGetName(ushort port, [NotNullWhen(true)] out string? name)
+	{
+		foreach (Pair pair in KnownPairs)
+		{
+			if (pair.Number == port)
+			{
+				name = pair.Name;
+				return true;
+			}
+		}
+
+		name = default;
+		return false;
+	}
+	#endregion
+
+	#region Operators
+	/// <summary>Compares two values to determine equality.</summary>
+	/// <param name="left">The value to compare with <paramref name="right"/>.</param>
+	/// <param name="right">The value to compare with <paramref name="left"/>.</param>
+	/// <returns><see langword="true"/> if <paramref name="left"/> is equal to <paramref name="right"/>, <see langword="false"/> otherwise.</returns>
+	public static bool operator ==(Port left, Port right) => left.Number == right.Number;
+
+	/// <summary>Compares two values to determine inequality.</summary>
+	/// <param name="left">The value to compare with <paramref name="right"/>.</param>
+	/// <param name="right">The value to compare with <paramref name="left"/>.</param>
+	/// <returns><see langword="true"/> if <paramref name="left"/> is not equal to <paramref name="right"/>, <see langword="false"/> otherwise.</returns>
+	public static bool operator !=(Port left, Port right) => left.Number != right.Number;
+
+	/// <summary>Compares two values to determine which is greater.</summary>
+	/// <param name="left">The value to compare with <paramref name="right"/>.</param>
+	/// <param name="right">The value to compare with <paramref name="left"/>.</param>
+	/// <returns><see langword="true"/> if <paramref name="left"/> is greater than <paramref name="right"/>, <see langword="false"/> otherwise.</returns>
+	public static bool operator >(Port left, Port right) => left.Number > right.Number;
+
+	/// <summary>Compares two values to determine which is greater or equal.</summary>
+	/// <param name="left">The value to compare with <paramref name="right"/>.</param>
+	/// <param name="right">The value to compare with <paramref name="left"/>.</param>
+	/// <returns><see langword="true"/> if <paramref name="left"/> is greater than or equal to <paramref name="right"/>, <see langword="false"/> otherwise.</returns>
+	public static bool operator >=(Port left, Port right) => left.Number >= right.Number;
+
+	/// <summary>Compares two values to determine which is lesser.</summary>
+	/// <param name="left">The value to compare with <paramref name="right"/>.</param>
+	/// <param name="right">The value to compare with <paramref name="left"/>.</param>
+	/// <returns><see langword="true"/> if <paramref name="left"/> is less than <paramref name="right"/>, <see langword="false"/> otherwise.</returns>
+	public static bool operator <(Port left, Port right) => left.Number < right.Number;
+
+	/// <summary>Compares two values to determine which is lesser or equal.</summary>
+	/// <param name="left">The value to compare with <paramref name="right"/>.</param>
+	/// <param name="right">The value to compare with <paramref name="left"/>.</param>
+	/// <returns><see langword="true"/> if <paramref name="left"/> is less than or equal to <paramref name="right"/>, <see langword="false"/> otherwise.</returns>
+	public static bool operator <=(Port left, Port right) => left.Number <= right.Number;
+	#endregion
+
+	#region Implicit operator
+	/// <summary>Implicitly converts the given port <paramref name="number"/> into a <see cref="Port"/> value.</summary>
+	/// <param name="number">The number to convert.</param>
+	public static implicit operator Port(ushort number) => new(number);
+
+	/// <summary>Implicitly converts the given <paramref name="port"/> into it's port number.</summary>
+	/// <param name="port">The port to convert.</param>
+	public static implicit operator ushort(Port port) => port.Number;
+	#endregion
+}

--- a/src/CommandLine.Tests/Parsing/Values/Networking/DnsEndPointValueParserTests.cs
+++ b/src/CommandLine.Tests/Parsing/Values/Networking/DnsEndPointValueParserTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+
+namespace OwlDomain.CommandLine.Tests.Parsing.Values.Networking;
+
+[TestClass]
+public sealed class DnsEndPointValueParserTests
+{
+	#region Tests
+	[DynamicData(nameof(VariousTests), DynamicDataSourceType.Method)]
+	[TestMethod]
+	public void Parse_Various_Successful(string[] fragments, string expectedHost, int expectedPort, bool isLazy)
+	{
+		// Arrange
+		IFlagValueParseContext context = Substitute.For<IFlagValueParseContext>();
+		TextParser parser = new(fragments, isLazy);
+		DnsEndPointValueParser sut = new();
+
+		// Act
+		IValueParseResult<DnsEndPoint> parseResult = sut.Parse(context, parser);
+
+		// Assert
+		CheckFailedResult(fragments, new(expectedHost, expectedPort), isLazy, parseResult);
+	}
+	#endregion
+
+	#region Helpers
+	[ExcludeFromCodeCoverage]
+	private static void CheckFailedResult(string[] fragments, DnsEndPoint expectedValue, bool isLazy, IValueParseResult<DnsEndPoint> result)
+	{
+		if (result.Successful is false)
+		{
+			string message = isLazy ? $"Lazy parsing failed for the command: {fragments[0]}" : $"Greedy parsing failed for the command: {string.Join("|", fragments)}";
+			message += "\n\nDiagnostics:";
+			if (result.Error is not null)
+				message += $"\n- [{result.Location}]: {result.Error}";
+
+			Assert.That.Fail(message + "\n");
+		}
+
+		TextToken[] tokens = [.. result.EnumerateTokens()];
+		TextTokenKind[] resultTokens = [.. tokens.Select(t => t.Kind)];
+		if (resultTokens.Length is not 1)
+		{
+			string message = isLazy ? $"Lazy parsing failed for the command: {fragments[0]}" : $"Greedy parsing failed for the command: {string.Join("|", fragments)}";
+			message += $"\n\nExpected tokens:\n{TextTokenKind.Value}";
+			message += $"\n\nResult tokens:\n{string.Join(' ', resultTokens)}";
+
+			Assert.That.Fail(message + "\n");
+		}
+
+		Debug.Assert(result.Value is not null);
+
+		bool areEqual =
+			result.Value.Host == expectedValue.Host &&
+			result.Value.Port == expectedValue.Port;
+
+		if (areEqual is false)
+		{
+			string message = isLazy ? $"Lazy parsing failed for the command: {fragments[0]}" : $"Greedy parsing failed for the command: {string.Join("|", fragments)}";
+			message += $"\nExpected value: {expectedValue}";
+			message += $"\nActual value: {result.Value}";
+
+			Assert.That.Fail(message + "\n");
+		}
+	}
+
+	[ExcludeFromCodeCoverage]
+	private static IEnumerable<object?[]> VariousTests()
+	{
+		string[] hosts =
+		[
+			"127.0.0.1",
+			"[0:0:0:0:0:0:0:1]",
+			"[::1]",
+			"localhost",
+			"example.com"
+		];
+
+		string[] separators = [":", ": ", " "];
+
+		string[] ports =
+		[
+			"80",
+			"http"
+		];
+
+		foreach (string host in hosts)
+			foreach (string separator in separators)
+				foreach (string port in ports)
+				{
+					string command = string.Concat(host, separator, port);
+
+					Port p = Port.Parse(port, null);
+
+					yield return
+					[
+						new string[] { command },
+						host,
+						p.Number,
+						true
+					];
+
+					yield return
+					[
+						command.Split(' ', StringSplitOptions.RemoveEmptyEntries),
+						host,
+						p.Number,
+						false
+					];
+				}
+	}
+	#endregion
+}

--- a/src/CommandLine.Tests/Parsing/Values/Networking/IPAddressValueParserTests.cs
+++ b/src/CommandLine.Tests/Parsing/Values/Networking/IPAddressValueParserTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+
+namespace OwlDomain.CommandLine.Tests.Parsing.Values.Networking;
+
+[TestClass]
+public sealed class IPAddressValueParserTests
+{
+	#region Tests
+	[DataRow(true, DisplayName = "Lazy mode")]
+	[DataRow(false, DisplayName = "Greedy mode")]
+	[TestMethod]
+	public void Parse_WithIPv4_Successful(bool isLazy)
+	{
+		// Arrange
+		const string input = "127.0.0.1";
+		IPAddress expectedValue = IPAddress.Parse(input);
+
+		IFlagValueParseContext context = Substitute.For<IFlagValueParseContext>();
+		TextParser parser = new([input], isLazy);
+		IPAddressValueParser sut = new();
+
+		// Act
+		IValueParseResult<IPAddress> parseResult = sut.Parse(context, parser);
+
+		// Assert
+		Assert.That
+			.IsTrue(parseResult.Successful)
+			.IsNull(parseResult.Error)
+			.AreEqual(parseResult.Value, expectedValue);
+	}
+
+	[DataRow(true, DisplayName = "Lazy mode")]
+	[DataRow(false, DisplayName = "Greedy mode")]
+	[TestMethod]
+	public void Parse_WithLongIPv6_Successful(bool isLazy)
+	{
+		// Arrange
+		const string input = "0:0:0:0:0:0:0:1";
+		IPAddress expectedValue = IPAddress.Parse(input);
+
+		IFlagValueParseContext context = Substitute.For<IFlagValueParseContext>();
+		TextParser parser = new([input], isLazy);
+		IPAddressValueParser sut = new();
+
+		// Act
+		IValueParseResult<IPAddress> parseResult = sut.Parse(context, parser);
+
+		// Assert
+		Assert.That
+			.IsTrue(parseResult.Successful)
+			.IsNull(parseResult.Error)
+			.AreEqual(parseResult.Value, expectedValue);
+	}
+
+	[DataRow(true, DisplayName = "Lazy mode")]
+	[DataRow(false, DisplayName = "Greedy mode")]
+	[TestMethod]
+	public void Parse_WithShortIPv6_Successful(bool isLazy)
+	{
+		// Arrange
+		const string input = "::1";
+		IPAddress expectedValue = IPAddress.Parse(input);
+
+		IFlagValueParseContext context = Substitute.For<IFlagValueParseContext>();
+		TextParser parser = new([input], isLazy);
+		IPAddressValueParser sut = new();
+
+		// Act
+		IValueParseResult<IPAddress> parseResult = sut.Parse(context, parser);
+
+		// Assert
+		Assert.That
+			.IsTrue(parseResult.Successful)
+			.IsNull(parseResult.Error)
+			.AreEqual(parseResult.Value, expectedValue);
+	}
+	#endregion
+}
+

--- a/src/CommandLine.Tests/Parsing/Values/Networking/IPEndPointValueParserTests.cs
+++ b/src/CommandLine.Tests/Parsing/Values/Networking/IPEndPointValueParserTests.cs
@@ -1,0 +1,111 @@
+using System.Net;
+
+namespace OwlDomain.CommandLine.Tests.Parsing.Values.Networking;
+
+[TestClass]
+public sealed class IPEndPointValueParserTests
+{
+	#region Tests
+	[DynamicData(nameof(VariousTests), DynamicDataSourceType.Method)]
+	[TestMethod]
+	public void Parse_Various_Successful(string[] fragments, string expectedAddress, int expectedPort, bool isLazy)
+	{
+		// Arrange
+		IFlagValueParseContext context = Substitute.For<IFlagValueParseContext>();
+		TextParser parser = new(fragments, isLazy);
+		IPEndPointValueParser sut = new();
+
+		// Act
+		IValueParseResult<IPEndPoint> parseResult = sut.Parse(context, parser);
+
+		// Assert
+		CheckFailedResult(fragments, new(IPAddress.Parse(expectedAddress), expectedPort), isLazy, parseResult);
+	}
+	#endregion
+
+	#region Helpers
+	[ExcludeFromCodeCoverage]
+	private static void CheckFailedResult(string[] fragments, IPEndPoint expectedValue, bool isLazy, IValueParseResult<IPEndPoint> result)
+	{
+		if (result.Successful is false)
+		{
+			string message = isLazy ? $"Lazy parsing failed for the command: {fragments[0]}" : $"Greedy parsing failed for the command: {string.Join("|", fragments)}";
+			message += "\n\nDiagnostics:";
+			if (result.Error is not null)
+				message += $"\n- [{result.Location}]: {result.Error}";
+
+			Assert.That.Fail(message + "\n");
+		}
+
+		TextToken[] tokens = [.. result.EnumerateTokens()];
+		TextTokenKind[] resultTokens = [.. tokens.Select(t => t.Kind)];
+		if (resultTokens.Length is not 1)
+		{
+			string message = isLazy ? $"Lazy parsing failed for the command: {fragments[0]}" : $"Greedy parsing failed for the command: {string.Join("|", fragments)}";
+			message += $"\n\nExpected tokens:\n{TextTokenKind.Value}";
+			message += $"\n\nResult tokens:\n{string.Join(' ', resultTokens)}";
+
+			Assert.That.Fail(message + "\n");
+		}
+
+		Debug.Assert(result.Value is not null);
+
+		bool areEqual =
+			result.Value.Address.Equals(expectedValue.Address) &&
+			result.Value.Port == expectedValue.Port;
+
+		if (areEqual is false)
+		{
+			string message = isLazy ? $"Lazy parsing failed for the command: {fragments[0]}" : $"Greedy parsing failed for the command: {string.Join("|", fragments)}";
+			message += $"\nExpected value: {expectedValue}";
+			message += $"\nActual value: {result.Value}";
+
+			Assert.That.Fail(message + "\n");
+		}
+	}
+
+	[ExcludeFromCodeCoverage]
+	private static IEnumerable<object?[]> VariousTests()
+	{
+		string[] addresses =
+		[
+			"127.0.0.1",
+			"[0:0:0:0:0:0:0:1]",
+			"[::1]",
+		];
+
+		string[] separators = [":", ": ", " "];
+
+		string[] ports =
+		[
+			"80",
+			"http"
+		];
+
+		foreach (string address in addresses)
+			foreach (string separator in separators)
+				foreach (string port in ports)
+				{
+					string command = string.Concat(address, separator, port);
+
+					Port p = Port.Parse(port, null);
+
+					yield return
+					[
+						new string[] { command },
+						address,
+						p.Number,
+						true
+					];
+
+					yield return
+					[
+						command.Split(' ', StringSplitOptions.RemoveEmptyEntries),
+						address,
+						p.Number,
+						false
+					];
+				}
+	}
+	#endregion
+}

--- a/src/CommandLine.Tests/global/global.Project.cs
+++ b/src/CommandLine.Tests/global/global.Project.cs
@@ -10,6 +10,7 @@ global using OwlDomain.CommandLine.Parsing.Values;
 global using OwlDomain.CommandLine.Parsing.Values.Networking;
 global using OwlDomain.CommandLine.Validation;
 global using OwlDomain.CommandLine.Execution;
+global using OwlDomain.CommandLine.SpecialTypes;
 
 
 global using DiagnosticSource = OwlDomain.CommandLine.Diagnostics.DiagnosticSource;

--- a/src/CommandLine.Tests/global/global.Project.cs
+++ b/src/CommandLine.Tests/global/global.Project.cs
@@ -7,6 +7,7 @@ global using OwlDomain.CommandLine.Diagnostics;
 global using OwlDomain.CommandLine.Discovery;
 global using OwlDomain.CommandLine.Parsing.Tree;
 global using OwlDomain.CommandLine.Parsing.Values;
+global using OwlDomain.CommandLine.Parsing.Values.Networking;
 global using OwlDomain.CommandLine.Validation;
 global using OwlDomain.CommandLine.Execution;
 

--- a/src/CommandLine/CommandEngineBuilder.cs
+++ b/src/CommandLine/CommandEngineBuilder.cs
@@ -113,7 +113,9 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 
 		IEngineSettings settings = EngineSettings.From(_settings);
 
+		WithSelector<NetworkingValueParserSelector>();
 		WithSelector<PrimitiveValueParserSelector>();
+
 		WithInjector<EngineCommandInjector>();
 
 		_nameExtractor ??= NameExtractor.Instance;

--- a/src/CommandLine/Parsing/Values/Networking/DnsEndPointValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Networking/DnsEndPointValueParser.cs
@@ -1,0 +1,88 @@
+using System.Net;
+
+namespace OwlDomain.CommandLine.Parsing.Values.Networking;
+
+/// <summary>
+/// 	Represents a parser for the <see cref="DnsEndPoint"/> type.
+/// </summary>
+public sealed class DnsEndPointValueParser : BaseValueParser<DnsEndPoint>
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override DnsEndPoint? TryParse(IValueParseContext context, ITextParser parser, out string? error)
+	{
+		string text = parser.AdvanceUntilBreak();
+
+		int colon = text.LastIndexOf(':');
+		int open = text.IndexOf('[');
+		int close = text.LastIndexOf(']');
+
+		if (open is not -1 ^ close is not -1)
+		{
+			error = $"Failed to parse '{text}' as an ip & port pair.";
+			return null;
+		}
+
+		ReadOnlySpan<char> hostSpan;
+		ReadOnlySpan<char> portSpan;
+
+		if (open is not -1 && close is not -1 && open != text.Length - 1 && close != 0)
+		{
+			hostSpan = text.AsSpan(open + 1, close - (open + 1));
+			if (colon > close && colon != text.Length - 1)
+				portSpan = text.AsSpan(colon + 1);
+			else
+			{
+				parser.SkipTrivia();
+				portSpan = parser.AdvanceUntilBreak();
+			}
+		}
+		else if (colon > 0 && colon != text.Length - 1)
+		{
+			hostSpan = text.AsSpan(0, colon);
+			portSpan = text.AsSpan(colon + 1);
+		}
+		else if (colon is -1)
+		{
+			hostSpan = text;
+			parser.SkipTrivia();
+			portSpan = parser.AdvanceUntilBreak();
+		}
+		else if (colon == text.Length - 1)
+		{
+			hostSpan = text.AsSpan(0, colon);
+			parser.SkipTrivia();
+			portSpan = parser.AdvanceUntilBreak();
+		}
+		else
+		{
+			error = $"Failed to parse '{text}' as an hostname & port pair.";
+			return null;
+		}
+
+		if (hostSpan.Length >= 2 && hostSpan[0] is '[' && hostSpan[^1] is ']')
+			hostSpan = hostSpan[1..^1];
+
+		string host;
+		if (hostSpan.Contains(':') && IPAddress.TryParse(hostSpan, out _))
+			host = $"[{hostSpan.ToString()}]";
+		else
+			host = hostSpan.ToString();
+
+		if (string.IsNullOrWhiteSpace(host))
+		{
+			error = $"Failed to parse '{hostSpan}' as an ip address.";
+			return null;
+		}
+
+		if (Port.TryParse(portSpan, null, out Port port) is false)
+		{
+			error = $"Failed to parse '{portSpan}' as a valid port number.";
+			return null;
+		}
+
+		error = default;
+		return new(host, port);
+	}
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Networking/IPAddressValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Networking/IPAddressValueParser.cs
@@ -1,0 +1,26 @@
+using System.Net;
+
+namespace OwlDomain.CommandLine.Parsing.Values.Networking;
+
+/// <summary>
+/// 	Represents a parser for the <see cref="IPAddress"/> type.
+/// </summary>
+public sealed class IPAddressValueParser : BaseValueParser<IPAddress>
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override IPAddress? TryParse(IValueParseContext context, ITextParser parser, out string? error)
+	{
+		string text = parser.AdvanceUntilBreak();
+
+		if (IPAddress.TryParse(text, out IPAddress? address))
+		{
+			error = default;
+			return address;
+		}
+
+		error = $"Failed to parse '{text}' as an ip address.";
+		return null;
+	}
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Networking/IPEndPointValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Networking/IPEndPointValueParser.cs
@@ -1,0 +1,93 @@
+using System.Net;
+
+namespace OwlDomain.CommandLine.Parsing.Values.Networking;
+
+/// <summary>
+/// 	Represents a parser for the <see cref="IPEndPoint"/> type.
+/// </summary>
+public sealed class IPEndPointValueParser : BaseValueParser<IPEndPoint>
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override IPEndPoint? TryParse(IValueParseContext context, ITextParser parser, out string? error)
+	{
+		string text = parser.AdvanceUntilBreak();
+
+		int colon = text.LastIndexOf(':');
+		int open = text.IndexOf('[');
+		int close = text.LastIndexOf(']');
+
+		if (open is not -1 ^ close is not -1)
+		{
+			error = $"Failed to parse '{text}' as an ip & port pair.";
+			return null;
+		}
+
+		if (open is not -1 && close is not -1)
+		{
+			if (colon > close && IPEndPoint.TryParse(text, out IPEndPoint? result))
+			{
+				error = default;
+				return result;
+			}
+		}
+		else if (colon is not -1 && IPEndPoint.TryParse(text, out IPEndPoint? result))
+		{
+			error = default;
+			return result;
+		}
+
+		ReadOnlySpan<char> addressSpan;
+		ReadOnlySpan<char> portSpan;
+
+		if (open is not -1 && close is not -1 && open != text.Length - 1 && close != 0)
+		{
+			addressSpan = text.AsSpan(open + 1, close - (open + 1));
+			if (colon > close && colon != text.Length - 1)
+				portSpan = text.AsSpan(colon + 1);
+			else
+			{
+				parser.SkipTrivia();
+				portSpan = parser.AdvanceUntilBreak();
+			}
+		}
+		else if (colon > 0 && colon != text.Length - 1)
+		{
+			addressSpan = text.AsSpan(0, colon);
+			portSpan = text.AsSpan(colon + 1);
+		}
+		else if (colon is -1)
+		{
+			addressSpan = text;
+			parser.SkipTrivia();
+			portSpan = parser.AdvanceUntilBreak();
+		}
+		else if (colon == text.Length - 1)
+		{
+			addressSpan = text.AsSpan(0, colon);
+			parser.SkipTrivia();
+			portSpan = parser.AdvanceUntilBreak();
+		}
+		else
+		{
+			error = $"Failed to parse '{text}' as an ip & port pair.";
+			return null;
+		}
+
+		if (IPAddress.TryParse(addressSpan, out IPAddress? address) is false)
+		{
+			error = $"Failed to parse '{addressSpan}' as an ip address.";
+			return null;
+		}
+
+		if (Port.TryParse(portSpan, null, out Port port) is false)
+		{
+			error = $"Failed to parse '{portSpan}' as a valid port number.";
+			return null;
+		}
+
+		error = default;
+		return new(address, port);
+	}
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Networking/NetworkingValueParserSelector.cs
+++ b/src/CommandLine/Parsing/Values/Networking/NetworkingValueParserSelector.cs
@@ -1,0 +1,20 @@
+using System.Net;
+
+namespace OwlDomain.CommandLine.Parsing.Values.Networking;
+
+/// <summary>
+/// 	Represents the value parser selector for networking types.
+/// </summary>
+public sealed class NetworkingValueParserSelector : BaseValueParserSelector
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override IValueParser? TrySelect(IRootValueParserSelector rootSelector, Type type)
+	{
+		if (type == typeof(IPAddress))
+			return new IPAddressValueParser();
+
+		return null;
+	}
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Networking/NetworkingValueParserSelector.cs
+++ b/src/CommandLine/Parsing/Values/Networking/NetworkingValueParserSelector.cs
@@ -14,6 +14,9 @@ public sealed class NetworkingValueParserSelector : BaseValueParserSelector
 		if (type == typeof(IPAddress))
 			return new IPAddressValueParser();
 
+		if (type == typeof(IPEndPoint))
+			return new IPEndPointValueParser();
+
 		return null;
 	}
 	#endregion

--- a/src/CommandLine/Parsing/Values/Networking/NetworkingValueParserSelector.cs
+++ b/src/CommandLine/Parsing/Values/Networking/NetworkingValueParserSelector.cs
@@ -20,6 +20,9 @@ public sealed class NetworkingValueParserSelector : BaseValueParserSelector
 		if (type == typeof(DnsEndPoint))
 			return new DnsEndPointValueParser();
 
+		if (type == typeof(Port))
+			return new PortValueParser();
+
 		return null;
 	}
 	#endregion

--- a/src/CommandLine/Parsing/Values/Networking/NetworkingValueParserSelector.cs
+++ b/src/CommandLine/Parsing/Values/Networking/NetworkingValueParserSelector.cs
@@ -17,6 +17,9 @@ public sealed class NetworkingValueParserSelector : BaseValueParserSelector
 		if (type == typeof(IPEndPoint))
 			return new IPEndPointValueParser();
 
+		if (type == typeof(DnsEndPoint))
+			return new DnsEndPointValueParser();
+
 		return null;
 	}
 	#endregion

--- a/src/CommandLine/Parsing/Values/Networking/PortValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Networking/PortValueParser.cs
@@ -1,0 +1,24 @@
+namespace OwlDomain.CommandLine.Parsing.Values.Networking;
+
+/// <summary>
+/// 	Represents a parser for the <see cref="Port"/> type.
+/// </summary>
+public sealed class PortValueParser : BaseValueParser<Port>
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override Port TryParse(IValueParseContext context, ITextParser parser, out string? error)
+	{
+		string text = parser.AdvanceUntilBreak();
+
+		if (Port.TryParse(text, null, out Port port))
+		{
+			error = default;
+			return port;
+		}
+
+		error = $"Failed to parse '{text}' as a port number.";
+		return default;
+	}
+	#endregion
+}

--- a/src/CommandLine/global/global.Project.cs
+++ b/src/CommandLine/global/global.Project.cs
@@ -17,6 +17,7 @@ global using OwlDomain.CommandLine.Discovery;
 global using OwlDomain.CommandLine.Documentation;
 global using OwlDomain.CommandLine.Parsing.Tree;
 global using OwlDomain.CommandLine.Parsing.Values;
+global using OwlDomain.CommandLine.Parsing.Values.Networking;
 global using OwlDomain.CommandLine.Validation;
 global using OwlDomain.CommandLine.Execution;
 

--- a/src/CommandLine/global/global.Project.cs
+++ b/src/CommandLine/global/global.Project.cs
@@ -20,6 +20,7 @@ global using OwlDomain.CommandLine.Parsing.Values;
 global using OwlDomain.CommandLine.Parsing.Values.Networking;
 global using OwlDomain.CommandLine.Validation;
 global using OwlDomain.CommandLine.Execution;
+global using OwlDomain.CommandLine.SpecialTypes;
 
 
 global using DiagnosticSource = OwlDomain.CommandLine.Diagnostics.DiagnosticSource;


### PR DESCRIPTION
This PR adds value parsers for networking types as per issue #16.

__Omitted:__
- FTP port alias as it's quite a combination of different ones it seems, not fully sure what to pick.
- No `localhost` alias for an IP address as turns out that can be messy and isn't always the loopback address (`127.0.0.1` or `::1`).
- No way to external add known port numbers.
- No port range specifiers as that can only be added once validator attributes are implemented.