### PR TITLE
Add path-like value parsers.

### DIFF
--- a/src/CommandLine/CommandEngineBuilder.cs
+++ b/src/CommandLine/CommandEngineBuilder.cs
@@ -113,6 +113,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 
 		IEngineSettings settings = EngineSettings.From(_settings);
 
+		WithSelector<PathValueParserSelector>();
 		WithSelector<NetworkingValueParserSelector>();
 		WithSelector<PrimitiveValueParserSelector>();
 

--- a/src/CommandLine/Parsing/Values/Paths/BaseFileSystemInfoValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Paths/BaseFileSystemInfoValueParser.cs
@@ -1,0 +1,40 @@
+using System.IO;
+
+namespace OwlDomain.CommandLine.Parsing.Values.Paths;
+
+/// <summary>
+/// 	Represents the base value parser for <see cref="FileSystemInfo"/> types.
+/// </summary>
+/// <typeparam name="T">The type to parse.</typeparam>
+public abstract class BaseFileSystemInfoValueParser<T> : BaseValueParser<T>
+	where T : FileSystemInfo
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override T? TryParse(IValueParseContext context, ITextParser parser, out string? error)
+	{
+		string text = parser.AdvanceUntilBreak();
+
+		try
+		{
+			T? value = TryCreate(text, out error);
+			return value;
+		}
+		catch (Exception exception)
+		{
+			error = exception.Message;
+			return default;
+		}
+	}
+
+	/// <summary>Tries to create a instance of the type <typeparamref name="T"/> from the given <paramref name="text"/>.</summary>
+	/// <param name="text">The text that was parsed.</param>
+	/// <param name="error">The error that occured during parsing.</param>
+	/// <returns>
+	/// 	The created value, or <see langword="null"/> if the value couldn't be created,
+	/// 	in which case the <paramref name="error"/> value should be set.
+	/// </returns>
+	/// <remarks>Exceptions will be caught automatically and they do not need to be handled by this method.</remarks>
+	protected abstract T? TryCreate(string text, out string? error);
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Paths/DirectoryInfoValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Paths/DirectoryInfoValueParser.cs
@@ -1,0 +1,18 @@
+using System.IO;
+
+namespace OwlDomain.CommandLine.Parsing.Values.Paths;
+
+/// <summary>
+/// 	Represents a value parser for the <see cref="DirectoryInfo"/> type.
+/// </summary>
+public sealed class DirectoryInfoValueParser : BaseFileSystemInfoValueParser<DirectoryInfo>
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override DirectoryInfo? TryCreate(string text, out string? error)
+	{
+		error = default;
+		return new(text);
+	}
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Paths/FileInfoValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Paths/FileInfoValueParser.cs
@@ -1,0 +1,18 @@
+using System.IO;
+
+namespace OwlDomain.CommandLine.Parsing.Values.Paths;
+
+/// <summary>
+/// 	Represents a value parser for the <see cref="FileInfo"/> type.
+/// </summary>
+public sealed class FileInfoValueParser : BaseFileSystemInfoValueParser<FileInfo>
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override FileInfo? TryCreate(string text, out string? error)
+	{
+		error = default;
+		return new(text);
+	}
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Paths/FileSystemInfoValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Paths/FileSystemInfoValueParser.cs
@@ -1,0 +1,73 @@
+using System.IO;
+
+namespace OwlDomain.CommandLine.Parsing.Values.Paths;
+
+/// <summary>
+/// 	Represents a value parser for the <see cref="FileSystemInfo"/> type.
+/// </summary>
+/// <remarks>
+/// 	This parser requires the path to exist, and it'll either select a <see cref="FileInfo"/>
+/// 	value or a <see cref="DirectoryInfo"/> depending on what the path is pointing to.
+/// </remarks>
+public sealed class FileSystemInfoValueParser : BaseFileSystemInfoValueParser<FileSystemInfo>
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override FileSystemInfo? TryCreate(string text, out string? error)
+	{
+		error = default;
+
+		if (text is "." or "..")
+			return new DirectoryInfo(text);
+
+		FileInfo? file = TryGetFile(text, out string? fileError);
+		if (file is not null)
+			return file;
+
+		DirectoryInfo? directory = TryGetDirectory(text, out string? directoryError);
+		if (directory is not null)
+			return directory;
+
+		error = fileError ?? directoryError ?? $"The given path '{text}' did not exist.";
+		return default;
+	}
+	private static FileInfo? TryGetFile(string text, out string? error)
+	{
+		try
+		{
+			error = default;
+
+			FileInfo file = new(text);
+
+			if (file.Exists)
+				return file;
+
+			return default;
+		}
+		catch (Exception exception)
+		{
+			error = exception.Message;
+			return default;
+		}
+	}
+	private static DirectoryInfo? TryGetDirectory(string text, out string? error)
+	{
+		try
+		{
+			error = default;
+
+			DirectoryInfo directory = new(text);
+
+			if (directory.Exists)
+				return directory;
+
+			return default;
+		}
+		catch (Exception exception)
+		{
+			error = exception.Message;
+			return default;
+		}
+	}
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Paths/PathValueParserSelector.cs
+++ b/src/CommandLine/Parsing/Values/Paths/PathValueParserSelector.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace OwlDomain.CommandLine.Parsing.Values.Paths;
 
 /// <summary>
@@ -11,6 +13,12 @@ public sealed class PathValueParserSelector : BaseValueParserSelector
 	{
 		if (type == typeof(Uri))
 			return new UriValueParser();
+
+		if (type == typeof(FileInfo))
+			return new FileInfoValueParser();
+
+		if (type == typeof(DirectoryInfo))
+			return new DirectoryInfoValueParser();
 
 		return default;
 	}

--- a/src/CommandLine/Parsing/Values/Paths/PathValueParserSelector.cs
+++ b/src/CommandLine/Parsing/Values/Paths/PathValueParserSelector.cs
@@ -1,0 +1,18 @@
+namespace OwlDomain.CommandLine.Parsing.Values.Paths;
+
+/// <summary>
+/// 	Represents the value parser selector for path-like types.
+/// </summary>
+public sealed class PathValueParserSelector : BaseValueParserSelector
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override IValueParser? TrySelect(IRootValueParserSelector rootSelector, Type type)
+	{
+		if (type == typeof(Uri))
+			return new UriValueParser();
+
+		return default;
+	}
+	#endregion
+}

--- a/src/CommandLine/Parsing/Values/Paths/PathValueParserSelector.cs
+++ b/src/CommandLine/Parsing/Values/Paths/PathValueParserSelector.cs
@@ -20,6 +20,9 @@ public sealed class PathValueParserSelector : BaseValueParserSelector
 		if (type == typeof(DirectoryInfo))
 			return new DirectoryInfoValueParser();
 
+		if (type == typeof(FileSystemInfo))
+			return new FileSystemInfoValueParser();
+
 		return default;
 	}
 	#endregion

--- a/src/CommandLine/Parsing/Values/Paths/UriValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Paths/UriValueParser.cs
@@ -1,0 +1,25 @@
+namespace OwlDomain.CommandLine.Parsing.Values.Paths;
+
+/// <summary>
+/// 	Represents a parser for the <see cref="Uri"/> type.
+/// </summary>
+public sealed class UriValueParser : BaseValueParser<Uri>
+{
+	#region Methods
+	/// <inheritdoc/>
+	protected override Uri? TryParse(IValueParseContext context, ITextParser parser, out string? error)
+	{
+		string text = parser.AdvanceUntilBreak();
+		try
+		{
+			error = default;
+			return new(text, UriKind.RelativeOrAbsolute);
+		}
+		catch (Exception exception)
+		{
+			error = exception.Message;
+			return default;
+		}
+	}
+	#endregion
+}

--- a/src/CommandLine/global/global.Project.cs
+++ b/src/CommandLine/global/global.Project.cs
@@ -18,6 +18,7 @@ global using OwlDomain.CommandLine.Documentation;
 global using OwlDomain.CommandLine.Parsing.Tree;
 global using OwlDomain.CommandLine.Parsing.Values;
 global using OwlDomain.CommandLine.Parsing.Values.Networking;
+global using OwlDomain.CommandLine.Parsing.Values.Paths;
 global using OwlDomain.CommandLine.Validation;
 global using OwlDomain.CommandLine.Execution;
 global using OwlDomain.CommandLine.SpecialTypes;


### PR DESCRIPTION
This PR adds path-like value parsers as per issue #18.

__Implemented:__
- [`Uri`](https://learn.microsoft.com/dotnet/api/system.uri) value parser.
- [`FileInfo`](https://learn.microsoft.com/dotnet/api/system.io.fileinfo) value parser.
- [`DirectoryInfo`](https://learn.microsoft.com/dotnet/api/system.io.directoryinfo) value parser.
- [`FileSystemInfo`](https://learn.microsoft.com/dotnet/api/system.io.filesysteminfo) value parser.
  - This one requires the file/directory to exist though since we don't have a way to know whether the developer wants to assume a file or a directory if doesn't exist on the file system.
  - Prioritises special directories like `..` and `.` first (since they should always exist), then tries to parse a file, and then tries to parse a directory.
