### PR TITLE
Support nullable values.

### DIFF
--- a/src/CommandLine.Abstractions/Arguments/IArgumentInfo.cs
+++ b/src/CommandLine.Abstractions/Arguments/IArgumentInfo.cs
@@ -18,6 +18,9 @@ public interface IArgumentInfo
 	/// <summary>Whether the argument has to be set when executing a command.</summary>
 	bool IsRequired { get; }
 
+	/// <summary>Whether the argument supports <see langword="null"/> values.</summary>
+	bool IsNullable { get; }
+
 	/// <summary>The default value for the argument.</summary>
 	object? DefaultValue { get; }
 

--- a/src/CommandLine.Abstractions/Flags/IFlagInfo.cs
+++ b/src/CommandLine.Abstractions/Flags/IFlagInfo.cs
@@ -21,6 +21,9 @@ public interface IFlagInfo
 	/// <summary>Whether the flag has to be set when executing a command.</summary>
 	bool IsRequired { get; }
 
+	/// <summary>Whether the flag supports <see langword="null"/> values.</summary>
+	bool IsNullable { get; }
+
 	/// <summary>The default value for the flag.</summary>
 	object? DefaultValue { get; }
 

--- a/src/CommandLine/Arguments/BaseArgumentInfo.cs
+++ b/src/CommandLine/Arguments/BaseArgumentInfo.cs
@@ -18,6 +18,9 @@ public abstract class BaseArgumentInfo<T> : IArgumentInfo<T>
 	public bool IsRequired { get; }
 
 	/// <inheritdoc/>
+	public bool IsNullable { get; }
+
+	/// <inheritdoc/>
 	public T? DefaultValue { get; }
 
 	/// <inheritdoc/>
@@ -35,6 +38,7 @@ public abstract class BaseArgumentInfo<T> : IArgumentInfo<T>
 	/// <param name="name">The name of the argument.</param>
 	/// <param name="position">The position of the argument.</param>
 	/// <param name="isRequired">Whether the argument has to be set when executing the command.</param>
+	/// <param name="isNullable">Whether the argument allows <see langword="null"/> values.</param>
 	/// <param name="defaultValue">The default value for the argument.</param>
 	/// <param name="parser">The value parser selected for the argument.</param>
 	/// <param name="documentation">The documentation for the argument.</param>
@@ -43,6 +47,7 @@ public abstract class BaseArgumentInfo<T> : IArgumentInfo<T>
 		string name,
 		int position,
 		bool isRequired,
+		bool isNullable,
 		T? defaultValue,
 		IValueParser<T> parser,
 		IDocumentationInfo? documentation,
@@ -54,6 +59,7 @@ public abstract class BaseArgumentInfo<T> : IArgumentInfo<T>
 		Name = name;
 		Position = position;
 		IsRequired = isRequired;
+		IsNullable = isNullable;
 		DefaultValue = defaultValue;
 		Parser = parser;
 		Documentation = documentation;

--- a/src/CommandLine/Arguments/BaseArgumentInfo.cs
+++ b/src/CommandLine/Arguments/BaseArgumentInfo.cs
@@ -56,6 +56,9 @@ public abstract class BaseArgumentInfo<T> : IArgumentInfo<T>
 		name.ThrowIfEmptyOrWhitespace(nameof(name));
 		position.ThrowIfLessThan(0, nameof(position));
 
+		if (isRequired is false && isNullable is false && defaultValue == null)
+			Throw.New.ArgumentException(nameof(defaultValue), "A default value of <null> cannot be used unless the argument is marked as nullable.");
+
 		Name = name;
 		Position = position;
 		IsRequired = isRequired;

--- a/src/CommandLine/Arguments/ParameterArgumentInfo.cs
+++ b/src/CommandLine/Arguments/ParameterArgumentInfo.cs
@@ -8,6 +8,7 @@ namespace OwlDomain.CommandLine.Arguments;
 /// <param name="name">The name of the argument.</param>
 /// <param name="position">The position of the argument.</param>
 /// <param name="isRequired">Whether the argument has to be set when executing the command.</param>
+/// <param name="isNullable">Whether the argument allows <see langword="null"/> values.</param>
 /// <param name="defaultValue">The default value for the argument.</param>
 /// <param name="parser">The value parser selected for the argument.</param>
 /// <param name="documentation">The documentation for the argument.</param>
@@ -17,11 +18,12 @@ public sealed class ParameterArgumentInfo<T>(
 	string name,
 	int position,
 	bool isRequired,
+	bool isNullable,
 	T? defaultValue,
 	IValueParser<T> parser,
 	IDocumentationInfo? documentation,
 	string? defaultValueLabel)
-	: BaseArgumentInfo<T>(name, position, isRequired, defaultValue, parser, documentation, defaultValueLabel), IParameterArgumentInfo<T>
+	: BaseArgumentInfo<T>(name, position, isRequired, isNullable, defaultValue, parser, documentation, defaultValueLabel), IParameterArgumentInfo<T>
 {
 	#region Properties
 	/// <inheritdoc/>

--- a/src/CommandLine/CommandEngineBuilder.cs
+++ b/src/CommandLine/CommandEngineBuilder.cs
@@ -14,6 +14,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 	#endregion
 
 	#region Fields
+	private readonly NullabilityInfoContext _nullabilityContext = new();
 	private readonly BuilderSettings _settings = new();
 	private readonly HashSet<Type> _classes = [];
 	private readonly List<IValueParserSelector> _selectors = [];
@@ -231,12 +232,8 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 				continue;
 			}
 
-#if NET7_0_OR_GREATER
 			bool isRequired = property.GetCustomAttribute<RequiredMemberAttribute>() is not null;
-#else
-			bool isRequired = false;
-#endif
-
+			bool isNullable = _nullabilityContext.Create(property).WriteState is NullabilityState.Nullable;
 			object? defaultValue = isRequired ? null : property.GetValue(instance);
 
 			string? longName = _nameExtractor.GetLongFlagName(property);
@@ -245,7 +242,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 			FlagKind kind = GetFlagKind(property.PropertyType, property.Name, longName, shortName);
 			IDocumentationInfo? documentation = _documentationProvider.GetInfo(property);
 
-			IPropertyFlagInfo flag = CreatePropertyFlag(property, kind, longName, shortName, isRequired, defaultValue, parser, documentation, null);
+			IPropertyFlagInfo flag = CreatePropertyFlag(property, kind, longName, shortName, isRequired, isNullable, defaultValue, parser, documentation, null);
 
 			flags.Add(flag);
 		}
@@ -275,11 +272,12 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 			int position = parameter.Position;
 
 			bool isRequired = parameter.HasDefaultValue is false;
+			bool isNullable = _nullabilityContext.Create(parameter).WriteState is NullabilityState.Nullable;
 			object? defaultValue = parameter.HasDefaultValue ? parameter.RawDefaultValue : null;
 			IValueParser parser = SelectValueParser(parameter);
 			IDocumentationInfo? documentation = _documentationProvider.GetInfo(parameter);
 
-			IArgumentInfo argument = CreateParameterArgument(parameter, name, position, isRequired, defaultValue, parser, documentation, null);
+			IArgumentInfo argument = CreateParameterArgument(parameter, name, position, isRequired, isNullable, defaultValue, parser, documentation, null);
 			arguments.Add(argument);
 		}
 
@@ -334,6 +332,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 			settings.ShortHelpFlagName,
 			false,
 			false,
+			false,
 			parser,
 			documentation,
 			null);
@@ -376,7 +375,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 	#region Helpers
 	private static FlagKind GetFlagKind(Type valueType, string originalName, string? longName, char? shortName)
 	{
-		if (valueType == typeof(bool))
+		if (valueType == typeof(bool) || valueType == typeof(bool?))
 			return FlagKind.Toggle;
 
 		if (IsVerbosityFlag(originalName, longName, shortName) && IsNumericType(valueType))
@@ -495,6 +494,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 		string? longName,
 		char? shortName,
 		bool isRequired,
+		bool isNullable,
 		object? defaultValue,
 		IValueParser parser,
 		IDocumentationInfo? documentation,
@@ -502,7 +502,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 	{
 		Type type = typeof(PropertyFlagInfo<>).MakeGenericType(property.PropertyType);
 
-		object? untyped = Activator.CreateInstance(type, [property, kind, longName, shortName, isRequired, defaultValue, parser, documentation, defaultValueLabel]);
+		object? untyped = Activator.CreateInstance(type, [property, kind, longName, shortName, isRequired, isNullable, defaultValue, parser, documentation, defaultValueLabel]);
 		Debug.Assert(untyped is not null);
 
 		return (IPropertyFlagInfo)untyped;
@@ -513,6 +513,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 		string? longName,
 		char? shortName,
 		bool isRequired,
+		bool isNullable,
 		object? defaultValue,
 		IValueParser parser,
 		IDocumentationInfo? documentation,
@@ -520,7 +521,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 	{
 		Type type = typeof(ParameterFlagInfo<>).MakeGenericType(parameter.ParameterType);
 
-		object? untyped = Activator.CreateInstance(type, [parameter, kind, longName, shortName, isRequired, defaultValue, parser, documentation, defaultValueLabel]);
+		object? untyped = Activator.CreateInstance(type, [parameter, kind, longName, shortName, isRequired, isNullable, defaultValue, parser, documentation, defaultValueLabel]);
 		Debug.Assert(untyped is not null);
 
 		return (IParameterFlagInfo)untyped;
@@ -530,6 +531,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 		string name,
 		int position,
 		bool isRequired,
+		bool isNullable,
 		object? defaultValue,
 		IValueParser parser,
 		IDocumentationInfo? documentation,
@@ -537,7 +539,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 	{
 		Type type = typeof(ParameterArgumentInfo<>).MakeGenericType(parameter.ParameterType);
 
-		object? untyped = Activator.CreateInstance(type, [parameter, name, position, isRequired, defaultValue, parser, documentation, defaultValueLabel]);
+		object? untyped = Activator.CreateInstance(type, [parameter, name, position, isRequired, isNullable, defaultValue, parser, documentation, defaultValueLabel]);
 		Debug.Assert(untyped is not null);
 
 		return (IParameterArgumentInfo)untyped;

--- a/src/CommandLine/CommandEngineBuilder.cs
+++ b/src/CommandLine/CommandEngineBuilder.cs
@@ -232,8 +232,11 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 				continue;
 			}
 
+			bool isNullable =
+				_nullabilityContext.Create(property).WriteState is NullabilityState.Nullable &&
+				property.GetCustomAttribute<DisallowNullAttribute>() is null;
+
 			bool isRequired = property.GetCustomAttribute<RequiredMemberAttribute>() is not null;
-			bool isNullable = _nullabilityContext.Create(property).WriteState is NullabilityState.Nullable;
 			object? defaultValue = isRequired ? null : property.GetValue(instance);
 
 			string? longName = _nameExtractor.GetLongFlagName(property);
@@ -271,8 +274,11 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 			string name = _nameExtractor.GetArgumentName(parameter.Name);
 			int position = parameter.Position;
 
+			bool isNullable =
+				_nullabilityContext.Create(parameter).WriteState is NullabilityState.Nullable &&
+				parameter.GetCustomAttribute<DisallowNullAttribute>() is null;
+
 			bool isRequired = parameter.HasDefaultValue is false;
-			bool isNullable = _nullabilityContext.Create(parameter).WriteState is NullabilityState.Nullable;
 			object? defaultValue = parameter.HasDefaultValue ? parameter.RawDefaultValue : null;
 			IValueParser parser = SelectValueParser(parameter);
 			IDocumentationInfo? documentation = _documentationProvider.GetInfo(parameter);

--- a/src/CommandLine/Flags/BaseFlagInfo.cs
+++ b/src/CommandLine/Flags/BaseFlagInfo.cs
@@ -21,6 +21,9 @@ public abstract class BaseFlagInfo<T> : IFlagInfo<T>
 	public bool IsRequired { get; }
 
 	/// <inheritdoc/>
+	public bool IsNullable { get; }
+
+	/// <inheritdoc/>
 	public T? DefaultValue { get; }
 
 	/// <inheritdoc/>
@@ -39,6 +42,7 @@ public abstract class BaseFlagInfo<T> : IFlagInfo<T>
 	/// <param name="longName">The long name of the flag.</param>
 	/// <param name="shortName">The short name of the flag.</param>
 	/// <param name="isRequired">Whether the flag has to be set when executing the command.</param>
+	/// <param name="isNullable">Whether the flag allows <see langword="null"/> values.</param>
 	/// <param name="defaultValue">The default value for the flag.</param>
 	/// <param name="parser">The value parser selected for the flag.</param>
 	/// <param name="documentation">The documentation for the flag.</param>
@@ -48,6 +52,7 @@ public abstract class BaseFlagInfo<T> : IFlagInfo<T>
 		string? longName,
 		char? shortName,
 		bool isRequired,
+		bool isNullable,
 		T? defaultValue,
 		IValueParser<T> parser,
 		IDocumentationInfo? documentation,
@@ -63,6 +68,7 @@ public abstract class BaseFlagInfo<T> : IFlagInfo<T>
 		LongName = longName;
 		ShortName = shortName;
 		IsRequired = isRequired;
+		IsNullable = isNullable;
 		DefaultValue = defaultValue;
 		Parser = parser;
 		Documentation = documentation;

--- a/src/CommandLine/Flags/BaseFlagInfo.cs
+++ b/src/CommandLine/Flags/BaseFlagInfo.cs
@@ -64,6 +64,9 @@ public abstract class BaseFlagInfo<T> : IFlagInfo<T>
 		if (longName is null && shortName is null)
 			Throw.New.ArgumentException(nameof(longName), "Either the long name or the short name of the flag must be specified at a minimum.");
 
+		if (isRequired is false && isNullable is false && defaultValue == null)
+			Throw.New.ArgumentException(nameof(defaultValue), "A default value of <null> cannot be used unless the flag is marked as nullable.");
+
 		Kind = kind;
 		LongName = longName;
 		ShortName = shortName;

--- a/src/CommandLine/Flags/ParameterFlagInfo.cs
+++ b/src/CommandLine/Flags/ParameterFlagInfo.cs
@@ -9,6 +9,7 @@ namespace OwlDomain.CommandLine.Flags;
 /// <param name="longName">The long name of the flag.</param>
 /// <param name="shortName">The short name of the flag.</param>
 /// <param name="isRequired">Whether the flag has to be set when executing the command.</param>
+/// <param name="isNullable">Whether the argument allows <see langword="null"/> values.</param>
 /// <param name="defaultValue">The default value for the flag.</param>
 /// <param name="parser">The value parser selected for the flag.</param>
 /// <param name="documentation">The documentation for the flag.</param>
@@ -19,11 +20,12 @@ public class ParameterFlagInfo<T>(
 	string? longName,
 	char? shortName,
 	bool isRequired,
+	bool isNullable,
 	T? defaultValue,
 	IValueParser<T> parser,
 	IDocumentationInfo? documentation,
 	string? defaultValueLabel)
-	: BaseFlagInfo<T>(kind, longName, shortName, isRequired, defaultValue, parser, documentation, defaultValueLabel), IParameterFlagInfo<T>
+	: BaseFlagInfo<T>(kind, longName, shortName, isRequired, isNullable, defaultValue, parser, documentation, defaultValueLabel), IParameterFlagInfo<T>
 {
 	#region Properties
 	/// <inheritdoc/>

--- a/src/CommandLine/Flags/PropertyFlagInfo.cs
+++ b/src/CommandLine/Flags/PropertyFlagInfo.cs
@@ -9,6 +9,7 @@ namespace OwlDomain.CommandLine.Flags;
 /// <param name="longName">The long name of the flag.</param>
 /// <param name="shortName">The short name of the flag.</param>
 /// <param name="isRequired">Whether the flag has to be set when executing the command.</param>
+/// <param name="isNullable">Whether the argument allows <see langword="null"/> values.</param>
 /// <param name="defaultValue">The default value for the flag.</param>
 /// <param name="parser">The value parser selected for the flag.</param>
 /// <param name="documentation">The documentation for the flag.</param>
@@ -19,11 +20,12 @@ public class PropertyFlagInfo<T>(
 	string? longName,
 	char? shortName,
 	bool isRequired,
+	bool isNullable,
 	T? defaultValue,
 	IValueParser<T> parser,
 	IDocumentationInfo? documentation,
 	string? defaultValueLabel)
-	: BaseFlagInfo<T>(kind, longName, shortName, isRequired, defaultValue, parser, documentation, defaultValueLabel), IPropertyFlagInfo<T>
+	: BaseFlagInfo<T>(kind, longName, shortName, isRequired, isNullable, defaultValue, parser, documentation, defaultValueLabel), IPropertyFlagInfo<T>
 {
 	#region Properties
 	/// <inheritdoc/>

--- a/src/CommandLine/Flags/VirtualFlagInfo.cs
+++ b/src/CommandLine/Flags/VirtualFlagInfo.cs
@@ -8,6 +8,7 @@ namespace OwlDomain.CommandLine.Flags;
 /// <param name="longName">The long name of the flag.</param>
 /// <param name="shortName">The short name of the flag.</param>
 /// <param name="isRequired">Whether the flag has to be set when executing the command.</param>
+/// <param name="isNullable">Whether the argument allows <see langword="null"/> values.</param>
 /// <param name="defaultValue">The default value for the flag.</param>
 /// <param name="parser">The value parser selected for the flag.</param>
 /// <param name="documentation">The documentation for the flag.</param>
@@ -17,10 +18,11 @@ public class VirtualFlagInfo<T>(
 	string? longName,
 	char? shortName,
 	bool isRequired,
+	bool isNullable,
 	T? defaultValue,
 	IValueParser<T> parser,
 	IDocumentationInfo? documentation,
 	string? defaultValueLabel)
-	: BaseFlagInfo<T>(kind, longName, shortName, isRequired, defaultValue, parser, documentation, defaultValueLabel), IVirtualFlagInfo<T>
+	: BaseFlagInfo<T>(kind, longName, shortName, isRequired, isNullable, defaultValue, parser, documentation, defaultValueLabel), IVirtualFlagInfo<T>
 {
 }

--- a/src/CommandLine/Parsing/Values/BaseValueParser.cs
+++ b/src/CommandLine/Parsing/Values/BaseValueParser.cs
@@ -92,7 +92,10 @@ public abstract class BaseValueParser<T> : IValueParser<T>
 	#endregion
 
 	#region Helpers
-	private static bool IsValueMissing(ITextParser parser)
+	/// <summary>Checks whether the next thing to parse is a missing value.</summary>
+	/// <param name="parser">The parser to use for the check.</param>
+	/// <returns><see langword="true"/> if the next thing to parse is a missing value, <see langword="false"/> otherwise.</returns>
+	public bool IsValueMissing(ITextParser parser)
 	{
 		if (parser.IsLazy)
 			return parser.IsAtEnd;
@@ -101,7 +104,11 @@ public abstract class BaseValueParser<T> : IValueParser<T>
 
 		return parser.IsAtEnd && parser.CurrentFragment.Length > 0;
 	}
-	private static bool IsEmptyValue(ITextParser parser)
+
+	/// <summary>Checks whether the next thing to parse is an empty value.</summary>
+	/// <param name="parser">The parser to use for the check.</param>
+	/// <returns><see langword="true"/> if the next thing to parse is an empty value, <see langword="false"/> otherwise.</returns>
+	public bool IsEmptyValue(ITextParser parser)
 	{
 		if (parser.IsLazy)
 			return false;

--- a/src/CommandLine/Parsing/Values/BaseValueParser.cs
+++ b/src/CommandLine/Parsing/Values/BaseValueParser.cs
@@ -32,8 +32,8 @@ public abstract class BaseValueParser<T> : IValueParser<T>
 		}
 		else if (AllowEmptyValues is false && IsEmptyValue(parser))
 		{
+			error = IsNullable(context) ? default : string.Empty;
 			value = default;
-			error = string.Empty;
 		}
 		else if (context is IFlagValueParseContext flag)
 			value = TryParse(flag, parser, out error);
@@ -116,6 +116,23 @@ public abstract class BaseValueParser<T> : IValueParser<T>
 		Debug.Assert(parser.IsGreedy);
 
 		return parser.CurrentFragment.Length is 0;
+	}
+
+	/// <summary>Checks whether the given parse <paramref name="context"/> allows <see langword="null"/> values.</summary>
+	/// <param name="context">The parse context to check.</param>
+	/// <returns>
+	/// 	<see langword="true"/> if the given parse <paramref name="context"/>
+	/// 	allows <see langword="null"/> values, <see langword="false"/> otherwise.
+	/// </returns>
+	public bool IsNullable(IValueParseContext context)
+	{
+		return context switch
+		{
+			IFlagValueParseContext flag => flag.Flag.IsNullable,
+			IArgumentValueParseContext argument => argument.Argument.IsNullable,
+
+			_ => Throw.New.ArgumentException<bool>(nameof(context), $"Unknown value parse context type ({context?.GetType()}).")
+		};
 	}
 	#endregion
 }

--- a/src/CommandLine/Parsing/Values/Primitives/NullableValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Primitives/NullableValueParser.cs
@@ -19,24 +19,13 @@ public sealed class NullableValueParser<T>(IValueParser<T> valueParser) : BaseVa
 
 	#region Methods
 	/// <inheritdoc/>
-	protected override T? TryParse(IArgumentValueParseContext context, ITextParser parser, out string? error)
-	{
-		return TryParse(context, parser, context.Argument.IsNullable, out error);
-	}
-
-	/// <inheritdoc/>
-	protected override T? TryParse(IFlagValueParseContext context, ITextParser parser, out string? error)
-	{
-		return TryParse(context, parser, context.Flag.IsNullable, out error);
-	}
-
-	private T? TryParse(IValueParseContext context, ITextParser parser, bool isNullable, out string? error)
+	protected override T? TryParse(IValueParseContext context, ITextParser parser, out string? error)
 	{
 		error = default;
 
 		if (IsEmptyValue(parser))
 		{
-			if (isNullable is false)
+			if (IsNullable(context) is false)
 				error = string.Empty;
 
 			return null;

--- a/src/CommandLine/Parsing/Values/Primitives/NullableValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Primitives/NullableValueParser.cs
@@ -19,20 +19,32 @@ public sealed class NullableValueParser<T>(IValueParser<T> valueParser) : BaseVa
 
 	#region Methods
 	/// <inheritdoc/>
-	protected override T? TryParse(IValueParseContext context, ITextParser parser, out string? error)
+	protected override T? TryParse(IArgumentValueParseContext context, ITextParser parser, out string? error)
 	{
+		return TryParse(context, parser, context.Argument.IsNullable, out error);
+	}
+
+	/// <inheritdoc/>
+	protected override T? TryParse(IFlagValueParseContext context, ITextParser parser, out string? error)
+	{
+		return TryParse(context, parser, context.Flag.IsNullable, out error);
+	}
+
+	private T? TryParse(IValueParseContext context, ITextParser parser, bool isNullable, out string? error)
+	{
+		error = default;
+
 		if (IsEmptyValue(parser))
 		{
-			error = default;
+			if (isNullable is false)
+				error = string.Empty;
+
 			return null;
 		}
 
 		IValueParseResult<T> result = _valueParser.Parse(context, parser);
 		if (result.Successful)
-		{
-			error = default;
 			return result.Value;
-		}
 
 		error = result.Error;
 		return default;

--- a/src/CommandLine/Parsing/Values/Primitives/NullableValueParser.cs
+++ b/src/CommandLine/Parsing/Values/Primitives/NullableValueParser.cs
@@ -1,0 +1,41 @@
+namespace OwlDomain.CommandLine.Parsing.Values.Primitives;
+
+/// <summary>
+/// 	Represents a generic parser for <see cref="Nullable{T}"/> types.
+/// </summary>
+/// <typeparam name="T">The non-nullable struct type to parse.</typeparam>
+/// <param name="valueParser">The parser for the non-nullable type.</param>
+public sealed class NullableValueParser<T>(IValueParser<T> valueParser) : BaseValueParser<T?>
+	where T : struct
+{
+	#region Fields
+	private readonly IValueParser<T> _valueParser = valueParser;
+	#endregion
+
+	#region Properties
+	/// <inheritdoc/>
+	protected override bool AllowEmptyValues => true;
+	#endregion
+
+	#region Methods
+	/// <inheritdoc/>
+	protected override T? TryParse(IValueParseContext context, ITextParser parser, out string? error)
+	{
+		if (IsEmptyValue(parser))
+		{
+			error = default;
+			return null;
+		}
+
+		IValueParseResult<T> result = _valueParser.Parse(context, parser);
+		if (result.Successful)
+		{
+			error = default;
+			return result.Value;
+		}
+
+		error = result.Error;
+		return default;
+	}
+	#endregion
+}


### PR DESCRIPTION
This PR adds support for nullable property/flag values as per issue #51.

__Features:__
- `BaseFlagInfo<T>` and `BaseArgumentInfo<T>` will now throw if it's not nullable, but it's default value is `null` (assuming it's an optional value).
- New generic `NullableValueParser<T>` (for nullable structs only) that can make use of other parsers for the value.
- Respects the [`DisallowNullAttribute`](https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.disallownullattribute).

__Notes:__
- Command value injection didn't really need any special handling since it's already possible for the value injectors to inspect the `PropertyInfo` and `ParameterInfo` themselves.
- I didn't add any helpers or extra parameters for showing if the value is nullable since it's unlikely for this to actually be needed, unless someone wants custom dependency injection, at which point it's better to let the dependency injection handle detecting this so that it's consistent with its own rules.