### PR TITLE
Improve documentation output.

### DIFF
--- a/src/CommandLine.Abstractions/Commands/IVirtualCommands.cs
+++ b/src/CommandLine.Abstractions/Commands/IVirtualCommands.cs
@@ -7,6 +7,11 @@ public interface IVirtualCommands
 {
 	#region Properties
 	/// <summary>The virtual help command.</summary>
+	/// <remarks>This command should show the project documentation.</remarks>
 	IVirtualCommandInfo? Help { get; }
+
+	/// <summary>The virtual help command.</summary>
+	/// <remarks>This command should show the project version.</remarks>
+	IVirtualCommandInfo? Version { get; }
 	#endregion
 }

--- a/src/CommandLine.Abstractions/Engine/BuilderSettings.cs
+++ b/src/CommandLine.Abstractions/Engine/BuilderSettings.cs
@@ -66,6 +66,12 @@ public sealed class BuilderSettings : IEngineSettings
 
 	/// <inheritdoc/>
 	public string FlagArgumentSeparator { get; set; } = "--";
+
+	/// <inheritdoc/>
+	public bool IncludeVersionCommand { get; set; } = true;
+
+	/// <inheritdoc/>
+	public string VersionCommandName { get; set; } = "version";
 	#endregion
 
 	#region Methods
@@ -283,6 +289,29 @@ public sealed class BuilderSettings : IEngineSettings
 		WithMergedFlagsPrefix("/");
 		ShortHelpFlagName = '?';
 
+		return this;
+	}
+
+	/// <summary>Sets the <see cref="IncludeVersionCommand"/> setting to <see langword="true"/>.</summary>
+	/// <param name="commandName">The name of the version command.</param>
+	/// <returns>The used builder instance.</returns>
+	/// <exception cref="ArgumentException">Thrown if the given <paramref name="commandName"/> is invalid.</exception>
+	public BuilderSettings WithVersionCommand(string commandName)
+	{
+		commandName.ThrowIfNullOrEmptyOrWhitespace(nameof(commandName));
+
+		IncludeVersionCommand = true;
+		VersionCommandName = commandName;
+
+		return this;
+	}
+
+
+	/// <summary>Sets the <see cref="IncludeVersionCommand"/> setting to <see langword="false"/>.</summary>
+	/// <returns>The used settings instance.</returns>
+	public BuilderSettings WithoutVersionCommand()
+	{
+		IncludeVersionCommand = false;
 		return this;
 	}
 	#endregion

--- a/src/CommandLine.Abstractions/Engine/BuilderSettings.cs
+++ b/src/CommandLine.Abstractions/Engine/BuilderSettings.cs
@@ -7,6 +7,15 @@ public sealed class BuilderSettings : IEngineSettings
 {
 	#region Properties
 	/// <inheritdoc/>
+	public string? Name { get; set; }
+
+	/// <inheritdoc/>
+	public string? Description { get; set; }
+
+	/// <inheritdoc/>
+	public string? Version { get; set; }
+
+	/// <inheritdoc/>
 	public bool AllowFlagShadowing { get; set; } = false;
 
 	/// <inheritdoc/>
@@ -60,6 +69,33 @@ public sealed class BuilderSettings : IEngineSettings
 	#endregion
 
 	#region Methods
+	/// <summary>Sets the <see cref="Name"/> setting.</summary>
+	/// <param name="name">The name of the project.</param>
+	/// <returns>The used builder instance.</returns>
+	public BuilderSettings WithName(string name)
+	{
+		Name = name;
+		return this;
+	}
+
+	/// <summary>Sets the <see cref="Description"/> setting.</summary>
+	/// <param name="description">The description of the project.</param>
+	/// <returns>The used builder instance.</returns>
+	public BuilderSettings WithDescription(string description)
+	{
+		Description = description;
+		return this;
+	}
+
+	/// <summary>Sets the <see cref="Version"/> setting.</summary>
+	/// <param name="version">The version of the project.</param>
+	/// <returns>The used builder instance.</returns>
+	public BuilderSettings WithVersion(string version)
+	{
+		Version = version;
+		return this;
+	}
+
 	/// <summary>Sets the <see cref="MergeLongAndShortFlags"/> setting to <see langword="true"/>.</summary>
 	/// <param name="prefix">The prefix to use for both long and short flags.</param>
 	/// <returns>The used builder instance.</returns>

--- a/src/CommandLine.Abstractions/Engine/BuilderSettings.cs
+++ b/src/CommandLine.Abstractions/Engine/BuilderSettings.cs
@@ -34,7 +34,7 @@ public sealed class BuilderSettings : IEngineSettings
 	public string HelpCommandName { get; set; } = "help";
 
 	/// <inheritdoc/>
-	public HashSet<string> FlagValueSeparators { get; } = [":", "=", " "];
+	public HashSet<string> FlagValueSeparators { get; } = ["=", ":", " "];
 	IReadOnlyCollection<string> IEngineSettings.FlagValueSeparators => FlagValueSeparators;
 
 	/// <inheritdoc/>

--- a/src/CommandLine.Abstractions/Engine/IEngineSettings.cs
+++ b/src/CommandLine.Abstractions/Engine/IEngineSettings.cs
@@ -6,6 +6,15 @@ namespace OwlDomain.CommandLine.Engine;
 public interface IEngineSettings
 {
 	#region Properties
+	/// <summary>The name of the project.</summary>
+	string? Name { get; }
+
+	/// <summary>The description of the project.</summary>
+	string? Description { get; }
+
+	/// <summary>The version of the project.</summary>
+	string? Version { get; }
+
 	/// <summary>Whether flag shadowing is allowed.</summary>
 	/// <remarks>
 	/// 	This indicates whether the flags from outer command groups can be shadows

--- a/src/CommandLine.Abstractions/Engine/IEngineSettings.cs
+++ b/src/CommandLine.Abstractions/Engine/IEngineSettings.cs
@@ -88,5 +88,12 @@ public interface IEngineSettings
 
 	/// <summary>The separator used to mark the end of flags, where everything after it is going to be parsed as arguments.</summary>
 	string FlagArgumentSeparator { get; }
+
+	/// <summary>Whether the help command should be included in every command group.</summary>
+	bool IncludeVersionCommand { get; }
+
+	/// <summary>The name of the virtual version command.</summary>
+	/// <remarks><see cref="IncludeVersionCommand"/> must be set to <see langword="true"/> for this setting to matter.</remarks>
+	string VersionCommandName { get; }
 	#endregion
 }

--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -22,6 +22,8 @@
 	<ItemGroup Label="packages">
 	  <PackageReference Include="OwlDomain.Common" Version="1.5.1" />
 	  <PackageReference Include="OwlDomain.Documentation" Version="1.0.4" />
+
+	  <PackageReference Include="Spectre.Console" Version="0.50.0" />
 	</ItemGroup>
 
 	<!-- NuGet package -->

--- a/src/CommandLine/Commands/VirtualCommands.cs
+++ b/src/CommandLine/Commands/VirtualCommands.cs
@@ -8,5 +8,8 @@ public sealed class VirtualCommands : IVirtualCommands
 	#region Properties
 	/// <inheritdoc/>
 	public IVirtualCommandInfo? Help { get; init; }
+
+	/// <inheritdoc/>
+	public IVirtualCommandInfo? Version { get; init; }
 	#endregion
 }

--- a/src/CommandLine/Documentation/DocumentationPrinter.cs
+++ b/src/CommandLine/Documentation/DocumentationPrinter.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using OwlDomain.Documentation.Document.Nodes;
+using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace OwlDomain.CommandLine.Documentation;
 
@@ -8,6 +10,20 @@ namespace OwlDomain.CommandLine.Documentation;
 /// </summary>
 public sealed class DocumentationPrinter : IDocumentationPrinter
 {
+	#region Constants
+	private const string HeaderStyle = "bold purple";
+	private const string SymbolStyle = "yellow";
+	private const string FlagPrefixStyle = SymbolStyle;
+	private const string FlagNameStyle = "blue";
+	private const string FlagValueStyle = "italic cyan";
+	private const string RequiredStyle = "bold yellow";
+	private const string OptionalStyle = "italic gray";
+	private const string GroupNameStyle = "green";
+	private const string CommandNameStyle = "lime";
+	private const string DefaultLabelStyle = "seagreen1";
+	private const string ArgumentStyle = "cyan";
+	#endregion
+
 	#region Methods
 	/// <inheritdoc/>
 	public void Print(ICommandEngine engine)
@@ -18,108 +34,336 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 	/// <inheritdoc/>
 	public void Print(ICommandEngine engine, ICommandGroupInfo group)
 	{
-		if (group.Groups.Count > 0)
-		{
-			Console.WriteLine("[Command groups]");
-			foreach (ICommandGroupInfo subGroup in group.Groups.Values)
-			{
-				Debug.Assert(subGroup.Name is not null);
-				Console.WriteLine($"{subGroup.Name} \t {GetBasicSummary(subGroup.Documentation)}");
-			}
+		List<IRenderable> items = [];
 
-			if (group.SharedFlags.Count > 0)
-				Console.WriteLine();
-		}
+		TryGetDocumentation(group.Documentation, items);
+		TryGetGroups(group.Groups, items);
+		TryGetFlags(engine.Settings, group.SharedFlags, items);
+		TryGetCommands(group.Commands, items);
 
-		if (group.SharedFlags.Count > 0)
-		{
-			Console.WriteLine("[Shared flags]");
-			foreach (IFlagInfo flag in group.SharedFlags)
-			{
-				if (flag.ShortName is not null)
-					Console.Write($"{engine.Settings.ShortFlagPrefix}{flag.ShortName}");
-
-				if (flag.LongName is not null)
-				{
-					if (flag.ShortName is not null)
-						Console.Write(' ');
-					Console.Write($"{engine.Settings.LongFlagPrefix}{flag.LongName}");
-				}
-
-				Console.WriteLine($" \t {GetBasicSummary(flag.Documentation)}");
-			}
-
-			if (group.Commands.Count > 0)
-				Console.WriteLine();
-		}
-
-		if (group.Commands.Count > 0)
-		{
-			Console.WriteLine("[Commands]");
-			foreach (ICommandInfo command in group.Commands.Values)
-			{
-				Debug.Assert(command.Name is not null);
-				Console.WriteLine($"{command.Name} \t {GetBasicSummary(command.Documentation)}");
-			}
-		}
+		PrintItems(items);
 	}
 
 	/// <inheritdoc/>
 	public void Print(ICommandEngine engine, ICommandInfo command)
 	{
-		if (command.Flags.Count > 0)
+		List<IRenderable> items = [];
+
+		TryGetDocumentation(command.Documentation, items);
+		TryGetExampleCommand(engine.Settings, command, items);
+		TryGetFlags(engine.Settings, command.Flags, items);
+		TryGetArguments(command.Arguments, items);
+
+		PrintItems(items);
+	}
+
+	private static void TryGetDocumentation(IDocumentationInfo? info, List<IRenderable> items)
+	{
+		if (info is null)
+			return;
+
+		TryGetDocumentation("Summary", info.Summary, items);
+		TryGetDocumentation("Remarks", info.Remarks, items);
+	}
+	private static void TryGetDocumentation(string header, IDocumentationNode? node, List<IRenderable> items)
+	{
+		if (node is null)
+			return;
+
+		IRenderable content = GetDocumentation(node);
+		IRenderable container = GetContainer(header, content);
+
+		items.Add(container);
+	}
+
+	private static void TryGetExampleCommand(IEngineSettings settings, ICommandInfo command, List<IRenderable> items)
+	{
+		IFlagInfo[] required = [.. command.Flags.Where(f => f.ValueInfo.IsRequired)];
+		IFlagInfo[] chained = settings.MergeLongAndShortFlags ? [] : [.. required.Where(f => f.Kind is FlagKind.Toggle or FlagKind.Repeat && f.ShortName is not null)];
+		IFlagInfo[] full = [.. required.Except(chained)];
+		IArgumentInfo[] arguments = [.. command.Arguments.Where(arg => arg.ValueInfo.IsRequired)];
+
+		List<string> parts = [];
+
+		ICommandGroupInfo? parent = command.Group;
+		while (parent is not null && parent.Name is not null)
 		{
-			Console.WriteLine("[Flags]");
-			foreach (IFlagInfo flag in command.Flags)
+			parts.Insert(0, $"[{GroupNameStyle}]{parent.Name}[/]");
+			parent = parent.Parent;
+		}
+
+		if (command.Name is not null)
+			parts.Add($"[{CommandNameStyle}]{command.Name.EscapeMarkup()}[/]");
+
+		string shortPrefix = $"[{FlagPrefixStyle}]{settings.ShortFlagPrefix.EscapeMarkup()}[/]";
+		string longPrefix = $"[{FlagPrefixStyle}]{settings.LongFlagPrefix.EscapeMarkup()}[/]";
+		string separator = $"[{SymbolStyle}]{settings.FlagValueSeparators.First()}[/]";
+
+		if (chained.Length > 0)
+		{
+			string current = shortPrefix;
+			foreach (IFlagInfo flag in chained)
 			{
-				if (flag.ShortName is not null)
-					Console.Write($"{engine.Settings.ShortFlagPrefix}{flag.ShortName}");
-
-				if (flag.LongName is not null)
-				{
-					if (flag.ShortName is not null)
-						Console.Write(' ');
-					Console.Write($"{engine.Settings.LongFlagPrefix}{flag.LongName}");
-				}
-
-				Console.WriteLine($" \t {GetBasicSummary(flag.Documentation)}");
+				string name = $"{flag.ShortName}".EscapeMarkup();
+				current += $"[{FlagNameStyle}]{name}[/]";
 			}
 
-			if (command.Arguments.Count > 0)
-				Console.WriteLine();
+			parts.Add(current);
 		}
 
-		if (command.Arguments.Count > 0)
+		foreach (IFlagInfo flag in full)
 		{
-			Console.WriteLine("[Arguments]");
-			foreach (IArgumentInfo argument in command.Arguments)
-				Console.WriteLine($"{argument.Name} \t {GetBasicSummary(argument.Documentation)}");
+			string current = flag.LongName is not null ? longPrefix : shortPrefix;
+			string? name = flag.LongName is not null ? flag.LongName : $"{flag.ShortName}";
+			Debug.Assert(name is not null);
+
+			current += $"[{FlagNameStyle}]{name.EscapeMarkup()}[/]";
+
+			if (flag.Kind is FlagKind.Regular)
+			{
+				string value = flag.LongName is not null ? flag.LongName.EscapeMarkup() : "value";
+				current += separator;
+				current += $"[gray]<[/][{FlagValueStyle}]{value}[/][gray]>[/]";
+			}
+
+			parts.Add(current);
 		}
+
+		foreach (IArgumentInfo argument in arguments)
+			parts.Add($"[gray]<[/][{ArgumentStyle}]{argument.Name.EscapeMarkup()}[/][gray]>[/]");
+
+		string text = string.Join(' ', parts);
+		Markup markup = new(text);
+
+		IRenderable container = GetContainer("Minimal example", markup);
+		items.Add(container);
+	}
+	private static void TryGetGroups(IReadOnlyDictionary<string, ICommandGroupInfo> groups, List<IRenderable> items)
+	{
+		if (groups.Count is 0)
+			return;
+
+		Table table = GetTable();
+		IRenderable container = GetContainer("Groups", table);
+		items.Add(container);
+
+		table.AddColumns([
+			GetTableColumn("name").LeftAligned(),
+			GetTableColumn("summary").LeftAligned()
+		]);
+
+		foreach (KeyValuePair<string, ICommandGroupInfo> group in groups)
+		{
+			Markup name = GetGroupName(group.Key);
+			Markup summary = GetDocumentation(group.Value.Documentation?.Summary);
+
+			table.AddRow(name, summary);
+		}
+	}
+	private static void TryGetCommands(IReadOnlyDictionary<string, ICommandInfo> commands, List<IRenderable> items)
+	{
+		if (commands.Count is 0)
+			return;
+
+		Table table = GetTable();
+		IRenderable container = GetContainer("Commands", table);
+		items.Add(container);
+
+		table.AddColumns([
+			GetTableColumn("name").LeftAligned(),
+			GetTableColumn("summary").LeftAligned()
+		]);
+
+		foreach (KeyValuePair<string, ICommandInfo> command in commands)
+		{
+			Markup name = GetCommandName(command.Key);
+			Markup summary = GetDocumentation(command.Value.Documentation?.Summary);
+
+			table.AddRow(name, summary);
+		}
+	}
+	private static void TryGetFlags(IEngineSettings settings, IReadOnlyCollection<IFlagInfo> flags, List<IRenderable> items)
+	{
+		if (flags.Count is 0)
+			return;
+
+		Table table = GetTable();
+		IRenderable container = GetContainer("Flags", table);
+		items.Add(container);
+
+		table.AddColumns([
+			GetTableColumn("short").LeftAligned(),
+			GetTableColumn("long").LeftAligned(),
+			GetTableColumn("required?").Centered(),
+			GetTableColumn("default").Centered(),
+			GetTableColumn("summary").LeftAligned()
+		]);
+
+		foreach (IFlagInfo flag in flags)
+		{
+			IRenderable shortName = GetShortFlag(settings, flag);
+			IRenderable longName = GetLongFlag(settings, flag);
+			IRenderable isRequired = GetIsRequired(flag.ValueInfo.IsRequired);
+			IRenderable defaultValueLabel = GetDefaultLabel(flag.DefaultValueInfo);
+			IRenderable summary = GetDocumentation(flag.Documentation?.Summary);
+
+			table.AddRow(shortName, longName, isRequired, defaultValueLabel, summary);
+		}
+	}
+	private static void TryGetArguments(IReadOnlyList<IArgumentInfo> arguments, List<IRenderable> items)
+	{
+		if (arguments.Count is 0)
+			return;
+
+		Table table = GetTable();
+		IRenderable container = GetContainer("Arguments", table);
+		items.Add(container);
+
+		table.AddColumns([
+			GetTableColumn("name").LeftAligned(),
+			GetTableColumn("required?").Centered(),
+			GetTableColumn("default").Centered(),
+			GetTableColumn("summary").LeftAligned()
+		]);
+
+		foreach (IArgumentInfo argument in arguments)
+		{
+			IRenderable name = GetArgumentName(argument.Name);
+			IRenderable isRequired = GetIsRequired(argument.ValueInfo.IsRequired);
+			IRenderable defaultValueLabel = GetDefaultLabel(argument.DefaultValueInfo);
+			IRenderable summary = GetDocumentation(argument.Documentation?.Summary);
+
+			table.AddRow(name, isRequired, defaultValueLabel, summary);
+		}
+	}
+	private static void PrintItems(IEnumerable<IRenderable> items)
+	{
+		List<IRenderable> actualItems = [];
+
+		foreach (IRenderable item in items)
+		{
+			if (actualItems.Count > 0)
+				actualItems.Add(Text.Empty);
+
+			actualItems.Add(item);
+		}
+
+		Rows rows = new(actualItems);
+		AnsiConsole.Write(rows);
 	}
 	#endregion
 
-	#region Helpers
-	private static string? GetBasicSummary(IDocumentationInfo? info)
+	#region Format helpers
+	private static Table GetTable()
+	{
+		Table table = new();
+
+		table.SimpleHeavyBorder();
+
+		return table;
+	}
+	private static TableColumn GetTableColumn(string header)
+	{
+		string escaped = header.EscapeMarkup();
+		IRenderable markup = new Markup($"[bold white]{escaped}[/]");
+		return new(markup);
+	}
+	private static IRenderable GetContainer(string header, IRenderable content)
+	{
+		string escaped = $"[{header}]".EscapeMarkup();
+
+		Panel panel = new(content)
+		{
+			Header = new($"[{HeaderStyle}]{escaped}[/]")
+		};
+
+		panel.RoundedBorder();
+
+		return panel;
+	}
+	private static Markup GetDefaultLabel(IDefaultValueInfo? info)
 	{
 		if (info is null)
-			return null;
+			return new("");
 
-		if (info.Summary is ITextDocumentationNode rootText)
-			return rootText.Text;
+		string escaped = info.Label.EscapeMarkup();
+		return new($"[{DefaultLabelStyle}]{escaped}[/]");
+	}
+	private static Markup GetArgumentName(string name)
+	{
+		string escaped = name.EscapeMarkup();
+		return new($"[{ArgumentStyle}]{escaped}[/]");
+	}
+	private static Markup GetCommandName(string? name)
+	{
+		if (name is null)
+			return new("");
 
-		if (info.Summary is IDocumentationNodeCollection collection)
+		string escaped = name.EscapeMarkup();
+		return new($"[{CommandNameStyle}]{escaped}[/]");
+	}
+	private static Markup GetGroupName(string? name)
+	{
+		if (name is null)
+			return new("");
+
+		string escaped = name.EscapeMarkup();
+		return new($"[{GroupNameStyle}]{escaped}[/]");
+	}
+	private static Markup GetIsRequired(bool isRequired)
+	{
+		if (isRequired)
+			return new($"[{RequiredStyle}]required[/]");
+
+		return new($"[{OptionalStyle}]optional[/]");
+	}
+	private static Markup GetShortFlag(IEngineSettings settings, IFlagInfo flag)
+	{
+		if (flag.ShortName is null)
+			return new("");
+
+		string prefix = settings.ShortFlagPrefix.EscapeMarkup();
+		string name = $"{flag.ShortName}".EscapeMarkup();
+
+		return new Markup($"[{FlagPrefixStyle}]{prefix}[/][{FlagNameStyle}]{name}[/]");
+	}
+	private static Markup GetLongFlag(IEngineSettings settings, IFlagInfo flag)
+	{
+		if (flag.LongName is null)
+			return new("");
+
+		string prefix = settings.LongFlagPrefix.EscapeMarkup();
+		string name = flag.LongName.EscapeMarkup();
+
+		return new Markup($"[{FlagPrefixStyle}]{prefix}[/][{FlagNameStyle}]{name}[/]");
+	}
+	private static Markup GetDocumentation(IDocumentationNode? node)
+	{
+		if (node is null)
+			return new("");
+
+		if (node is ITextDocumentationNode rootText)
+		{
+			string escaped = rootText.Text.EscapeMarkup();
+			return new(escaped);
+		}
+
+		if (node is IDocumentationNodeCollection collection)
 		{
 			StringBuilder builder = new();
 
-			foreach (IDocumentationNode node in collection.Children)
+			foreach (IDocumentationNode child in collection.Children)
 			{
-				if (node is ITextDocumentationNode text) builder.Append(text.Text);
+				if (child is ITextDocumentationNode text) builder.Append(text.Text);
 			}
 
-			return builder.ToString();
+			string fullText = builder.ToString();
+			string escaped = fullText.EscapeMarkup();
+
+			return new(escaped);
 		}
 
-		return null;
+		return new("");
 	}
 	#endregion
 }

--- a/src/CommandLine/Engine/EngineSettings.cs
+++ b/src/CommandLine/Engine/EngineSettings.cs
@@ -7,6 +7,15 @@ public sealed class EngineSettings : IEngineSettings
 {
 	#region Properties
 	/// <inheritdoc/>
+	public required string? Name { get; init; }
+
+	/// <inheritdoc/>
+	public required string? Description { get; init; }
+
+	/// <inheritdoc/>
+	public required string? Version { get; init; }
+
+	/// <inheritdoc/>
 	public required bool AllowFlagShadowing { get; init; }
 
 	/// <inheritdoc/>
@@ -88,6 +97,10 @@ public sealed class EngineSettings : IEngineSettings
 
 		return new EngineSettings()
 		{
+			Name = settings.Name,
+			Description = settings.Description,
+			Version = settings.Version,
+
 			AllowFlagShadowing = settings.AllowFlagShadowing,
 
 			LongFlagPrefix = settings.LongFlagPrefix,

--- a/src/CommandLine/Engine/EngineSettings.cs
+++ b/src/CommandLine/Engine/EngineSettings.cs
@@ -65,6 +65,12 @@ public sealed class EngineSettings : IEngineSettings
 
 	/// <inheritdoc/>
 	public required string FlagArgumentSeparator { get; init; }
+
+	/// <inheritdoc/>
+	public required bool IncludeVersionCommand { get; init; }
+
+	/// <inheritdoc/>
+	public required string VersionCommandName { get; init; }
 	#endregion
 
 	#region Functions
@@ -91,6 +97,9 @@ public sealed class EngineSettings : IEngineSettings
 		if (settings.ParsingTimeout < TimeSpan.Zero) errors.Add($"The {nameof(ParsingTimeout)} setting must not be negative.");
 		if (settings.ValidationTimeout < TimeSpan.Zero) errors.Add($"The {nameof(ValidationTimeout)} setting must not be negative.");
 		if (settings.ExecutionTimeout < TimeSpan.Zero) errors.Add($"The {nameof(ExecutionTimeout)} setting must not be negative.");
+
+		if (settings.IncludeVersionCommand && string.IsNullOrWhiteSpace(settings.VersionCommandName))
+			errors.Add($"{nameof(IncludeVersionCommand)} setting was set to true, but the {nameof(VersionCommandName)} setting ({settings.VersionCommandName}) was invalid.");
 
 		if (errors.Count > 0)
 			Throw.New.ArgumentException(nameof(settings), string.Join(Environment.NewLine, errors));
@@ -123,6 +132,9 @@ public sealed class EngineSettings : IEngineSettings
 			ParsingTimeout = settings.ParsingTimeout,
 			ValidationTimeout = settings.ValidationTimeout,
 			ExecutionTimeout = settings.ExecutionTimeout,
+
+			IncludeVersionCommand = settings.IncludeVersionCommand,
+			VersionCommandName = settings.VersionCommandName,
 		};
 	}
 	#endregion

--- a/src/CommandLine/Execution/CommandExecutor.cs
+++ b/src/CommandLine/Execution/CommandExecutor.cs
@@ -14,9 +14,6 @@ public sealed class CommandExecutor : ICommandExecutor
 	/// <inheritdoc/>
 	public ICommandExecutorResult Execute(ICommandValidatorResult validatorResult, CommandExecutionDelegate? callback = null)
 	{
-		if (validatorResult.Successful is false)
-			return new CommandExecutorResult(false, validatorResult.WasCancelled, validatorResult, new DiagnosticBag(), default, default);
-
 		Stopwatch watch = Stopwatch.StartNew();
 		DiagnosticBag diagnostics = [];
 
@@ -77,6 +74,9 @@ public sealed class CommandExecutor : ICommandExecutor
 				return new CommandExecutorResult(diagnostics.Any() is false, false, validatorResult, diagnostics, watch.Elapsed, context.ResultValue);
 			}
 		}
+
+		if (validatorResult.Successful is false)
+			return new CommandExecutorResult(false, validatorResult.WasCancelled, validatorResult, new DiagnosticBag(), default, default);
 
 		if (validatorResult.ParserResult.LeafCommand is not ICommandParseResult command)
 		{

--- a/src/CommandLine/Execution/CommandExecutor.cs
+++ b/src/CommandLine/Execution/CommandExecutor.cs
@@ -51,7 +51,7 @@ public sealed class CommandExecutor : ICommandExecutor
 
 		CommandExecutionContext context = new(diagnostics, validatorResult.Engine, groupTarget, commandTarget, arguments, flags, validatorResult, cancellationTokenSource);
 
-		if (callback is not null || OnExecute is null)
+		if (callback is not null || OnExecute is not null)
 		{
 			callback?.Invoke(context);
 			cancellationTokenSource.Token.ThrowIfCancellationRequested();


### PR DESCRIPTION
This PR improves the documentation output using [`Spectre.Console`](https://github.com/spectreconsole/spectre.console) as per issue #57.

__Features:__
- Improved the default documentation printer.
- Added project information to the engine settings.
- Added virtual `version` command.