### PR TITLE
Add extra documentation support.

### DIFF
--- a/src/CommandLine.Abstractions/Documentation/IDocumentationInfo.cs
+++ b/src/CommandLine.Abstractions/Documentation/IDocumentationInfo.cs
@@ -9,9 +9,15 @@ public interface IDocumentationInfo
 {
 	#region Properties
 	/// <summary>The summary information.</summary>
-	IDocumentationNode Summary { get; }
+	IDocumentationNode? Summary { get; }
 
 	/// <summary>The remarks information.</summary>
 	IDocumentationNode? Remarks { get; }
+
+	/// <summary>The example information.</summary>
+	IDocumentationNode? Example { get; }
+
+	/// <summary>The return value information.</summary>
+	IDocumentationNode? Returns { get; }
 	#endregion
 }

--- a/src/CommandLine/Documentation/DocumentationInfo.cs
+++ b/src/CommandLine/Documentation/DocumentationInfo.cs
@@ -5,13 +5,28 @@ namespace OwlDomain.CommandLine.Documentation;
 /// <summary>
 ///	Represents a container for documentation information.
 /// </summary>
-public sealed class DocumentationInfo(IDocumentationNode summary, IDocumentationNode? remarks) : IDocumentationInfo
+/// <param name="summary">The summary information.</param>
+/// <param name="remarks">The remarks information.</param>
+/// <param name="example">The example informatino.</param>
+/// <param name="returns">The return value information.</param>
+public sealed class DocumentationInfo(
+	IDocumentationNode? summary = null,
+	IDocumentationNode? remarks = null,
+	IDocumentationNode? example = null,
+	IDocumentationNode? returns = null)
+	: IDocumentationInfo
 {
 	#region Properties
 	/// <inheritdoc/>
-	public IDocumentationNode Summary { get; } = summary;
+	public IDocumentationNode? Summary { get; } = summary;
 
 	/// <inheritdoc/>
 	public IDocumentationNode? Remarks { get; } = remarks;
+
+	/// <inheritdoc/>
+	public IDocumentationNode? Example { get; } = example;
+
+	/// <inheritdoc/>
+	public IDocumentationNode? Returns { get; } = returns;
 	#endregion
 }

--- a/src/CommandLine/Documentation/DocumentationPrinter.cs
+++ b/src/CommandLine/Documentation/DocumentationPrinter.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using OwlDomain.Documentation;
 using OwlDomain.Documentation.Document.Nodes;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -10,6 +11,155 @@ namespace OwlDomain.CommandLine.Documentation;
 /// </summary>
 public sealed class DocumentationPrinter : IDocumentationPrinter
 {
+	#region Nested types
+	private sealed class Lookup : Dictionary<string, object>
+	{
+		#region Fields
+		private static readonly DocumentationIdGenerator Generator = new();
+		#endregion
+
+		#region Properties
+		public ICommandGroupInfo Group { get; }
+		#endregion
+
+		#region Constructors
+		public Lookup(ICommandGroupInfo group)
+		{
+			Group = group;
+			Populate(group);
+		}
+		#endregion
+
+		#region Methods
+		private void Populate(ICommandGroupInfo group)
+		{
+			Populate(group.SharedFlags);
+			Populate(group.Groups.Values);
+			Populate(group.Commands.Values);
+
+			if (group.ImplicitCommand is not null)
+				Populate(group.ImplicitCommand);
+		}
+		private void Populate(ICommandInfo command)
+		{
+			Populate(command.Flags);
+
+			if (command is IMethodCommandInfo method)
+				Populate(method.Method, command);
+		}
+		private void Populate(IFlagInfo flag)
+		{
+			if (flag is IPropertyFlagInfo property)
+				Populate(property.Property, flag);
+		}
+		#endregion
+
+		#region Helpers
+		private void Populate(PropertyInfo property, object target)
+		{
+			string id = Generator.Get(property);
+			TryAdd(id, target);
+		}
+		private void Populate(MethodInfo method, object target)
+		{
+			string id = Generator.Get(method);
+			TryAdd(id, target);
+		}
+		private void Populate(IEnumerable<ICommandGroupInfo> groups)
+		{
+			foreach (ICommandGroupInfo group in groups)
+				Populate(group);
+		}
+		private void Populate(IEnumerable<ICommandInfo> commands)
+		{
+			foreach (ICommandInfo command in commands)
+				Populate(command);
+		}
+		private void Populate(IEnumerable<IFlagInfo> flags)
+		{
+			foreach (IFlagInfo flag in flags)
+				Populate(flag);
+		}
+		#endregion
+	}
+	private sealed class ParameterLookup : Dictionary<string, object>
+	{
+		#region Properties
+		public ICommandInfo Command { get; }
+		#endregion
+
+		#region Constructors
+		public ParameterLookup(ICommandInfo command)
+		{
+			Command = command;
+			Populate(command);
+		}
+		#endregion
+
+		#region Methods
+		private void Populate(ICommandInfo command)
+		{
+			Populate(command.Flags);
+			Populate(command.Arguments);
+		}
+		private void Populate(IFlagInfo flag)
+		{
+			if (flag is IParameterFlagInfo parameter)
+				Populate(parameter.Parameter, flag);
+		}
+		private void Populate(IArgumentInfo argument)
+		{
+			if (argument is IParameterArgumentInfo parameter)
+				Populate(parameter.Parameter, argument);
+		}
+		#endregion
+
+		#region Helpers
+		private void Populate(ParameterInfo parameter, object target)
+		{
+			if (parameter.Name is not null)
+				TryAdd(parameter.Name, target);
+		}
+		private void Populate(IEnumerable<IFlagInfo> flags)
+		{
+			foreach (IFlagInfo flag in flags)
+				Populate(flag);
+		}
+		private void Populate(IEnumerable<IArgumentInfo> arguments)
+		{
+			foreach (IArgumentInfo argument in arguments)
+				Populate(argument);
+		}
+		#endregion
+	}
+	private class Context(ICommandEngine engine, Lookup lookup)
+	{
+		#region Properties
+		public ICommandEngine Engine { get; } = engine;
+		public IEngineSettings Settings { get; } = engine.Settings;
+		public Lookup Lookup { get; } = lookup;
+		#endregion
+
+		#region Constructors
+		public Context(ICommandEngine engine) : this(engine, new(engine.RootGroup)) { }
+		#endregion
+	}
+	private class GroupContext(Context context, ICommandGroupInfo group) : Context(context.Engine, context.Lookup)
+	{
+		#region Fields
+		public ICommandGroupInfo Group { get; } = group;
+		#endregion
+	}
+	private class CommandContext(Context context, ICommandInfo command) : Context(context.Engine, context.Lookup)
+	{
+		#region Fields
+		public ICommandGroupInfo? Group { get; } = command.Group;
+		public ICommandInfo Command { get; } = command;
+		public ParameterLookup Parameters { get; } = new(command);
+		#endregion
+	}
+	#endregion
+
 	#region Constants
 	private const string ColumnHeaderStyle = "bold";
 	private const string HeaderStyle = "bold italic";
@@ -19,19 +169,19 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 	private const string FlagStyle = "fuchsia";
 	private const string RequiredStyle = "bold";
 	private const string OptionalStyle = "italic";
-	private const string DefaultLabelStyle = "italic";
 	#endregion
 
 	#region Methods
 	/// <inheritdoc/>
 	public void Print(ICommandEngine engine)
 	{
+		Context context = new(engine);
 		List<IRenderable> items = [];
 
-		TryGetProjectInfo(engine.Settings, items);
-		TryGetGroups(engine.RootGroup.Groups, items);
-		TryGetFlags(engine.Settings, engine.RootGroup.SharedFlags, items);
-		TryGetCommands(engine.RootGroup.Commands, items);
+		TryGetProjectInfo(context, items);
+		TryGetGroups(context, engine.RootGroup.Groups, items);
+		TryGetFlags(context, engine.RootGroup.SharedFlags, items);
+		TryGetCommands(context, engine.RootGroup.Commands, items);
 
 		PrintItems(items);
 	}
@@ -45,12 +195,13 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 			return;
 		}
 
+		GroupContext context = new(new(engine), group);
 		List<IRenderable> items = [];
 
-		TryGetDocumentation(group.Documentation, items);
-		TryGetGroups(group.Groups, items);
-		TryGetFlags(engine.Settings, group.SharedFlags, items);
-		TryGetCommands(group.Commands, items);
+		TryGetDocumentation(context, group.Documentation, items);
+		TryGetGroups(context, group.Groups, items);
+		TryGetFlags(context, group.SharedFlags, items);
+		TryGetCommands(context, group.Commands, items);
 
 		PrintItems(items);
 	}
@@ -58,26 +209,27 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 	/// <inheritdoc/>
 	public void Print(ICommandEngine engine, ICommandInfo command)
 	{
+		CommandContext context = new(new(engine), command);
 		List<IRenderable> items = [];
 
-		TryGetDocumentation(command.Documentation, items);
-		TryGetExampleCommand(engine.Settings, command, items);
-		TryGetFlags(engine.Settings, command.Flags, items);
-		TryGetArguments(command.Arguments, items);
+		TryGetDocumentation(context, command.Documentation, items);
+		TryGetExampleCommand(context, items);
+		TryGetFlags(context, command.Flags, items);
+		TryGetArguments(context, command.Arguments, items);
 
 		PrintItems(items);
 	}
 
-	private static void TryGetProjectInfo(IEngineSettings settings, List<IRenderable> items)
+	private static void TryGetProjectInfo(Context context, List<IRenderable> items)
 	{
-		if (settings.Name is null && settings.Description is null && settings.Version is null)
+		if (context.Settings.Name is null && context.Settings.Description is null && context.Settings.Version is null)
 			return;
 
-		string? version = settings.Version;
+		string? version = context.Settings.Version;
 		if (version is not null && version.Length > 0 && char.IsDigit(version[0]))
 			version = "v" + version;
 
-		string header = (settings.Name, version) switch
+		string header = (context.Settings.Name, version) switch
 		{
 			(string name, string) => $"{name.EscapeMarkup()} - {version.EscapeMarkup()}",
 			(null, string) => $"program - {version.EscapeMarkup()}",
@@ -86,54 +238,56 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 			_ => "program",
 		};
 
-		string descriptionText = settings.Description?.EscapeMarkup() ?? "No description.";
+		string descriptionText = context.Settings.Description?.EscapeMarkup() ?? "No description.";
 		Markup description = new(descriptionText.PadRight(header.Length + 2));
 
 		IRenderable container = GetContainer(header, description);
 
 		items.Add(container);
 	}
-	private static void TryGetDocumentation(IDocumentationInfo? info, List<IRenderable> items)
+	private static void TryGetDocumentation(Context context, IDocumentationInfo? info, List<IRenderable> items)
 	{
 		if (info is null)
 			return;
 
-		TryGetDocumentation("Summary", info.Summary, items);
-		TryGetDocumentation("Remarks", info.Remarks, items);
+		TryGetDocumentation(context, "Summary", info.Summary, items);
+		TryGetDocumentation(context, "Remarks", info.Remarks, items);
+		TryGetDocumentation(context, "Example", info.Example, items);
+		TryGetDocumentation(context, "Returns", info.Returns, items);
 	}
-	private static void TryGetDocumentation(string header, IDocumentationNode? node, List<IRenderable> items)
+	private static void TryGetDocumentation(Context context, string header, IDocumentationNode? node, List<IRenderable> items)
 	{
 		if (node is null)
 			return;
 
-		IRenderable content = GetDocumentation(node);
+		IRenderable content = GetDocumentation(context, node);
 		IRenderable container = GetContainer(header, content);
 
 		items.Add(container);
 	}
 
-	private static void TryGetExampleCommand(IEngineSettings settings, ICommandInfo command, List<IRenderable> items)
+	private static void TryGetExampleCommand(CommandContext context, List<IRenderable> items)
 	{
-		IFlagInfo[] required = [.. command.Flags.Where(f => f.ValueInfo.IsRequired)];
-		IFlagInfo[] chained = settings.MergeLongAndShortFlags ? [] : [.. required.Where(f => f.Kind is FlagKind.Toggle or FlagKind.Repeat && f.ShortName is not null)];
+		IFlagInfo[] required = [.. context.Command.Flags.Where(f => f.ValueInfo.IsRequired)];
+		IFlagInfo[] chained = context.Settings.MergeLongAndShortFlags ? [] : [.. required.Where(f => f.Kind is FlagKind.Toggle or FlagKind.Repeat && f.ShortName is not null)];
 		IFlagInfo[] full = [.. required.Except(chained)];
-		IArgumentInfo[] arguments = [.. command.Arguments.Where(arg => arg.ValueInfo.IsRequired)];
+		IArgumentInfo[] arguments = [.. context.Command.Arguments.Where(arg => arg.ValueInfo.IsRequired)];
 
 		List<string> parts = [];
 
-		ICommandGroupInfo? parent = command.Group;
+		ICommandGroupInfo? parent = context.Command.Group;
 		while (parent is not null && parent.Name is not null)
 		{
 			parts.Insert(0, $"[{GroupStyle}]{parent.Name}[/]");
 			parent = parent.Parent;
 		}
 
-		if (command.Name is not null)
-			parts.Add($"[{CommandStyle}]{command.Name.EscapeMarkup()}[/]");
+		if (context.Command.Name is not null)
+			parts.Add($"[{CommandStyle}]{context.Command.Name.EscapeMarkup()}[/]");
 
-		string shortPrefix = $"[{FlagStyle}]{settings.ShortFlagPrefix.EscapeMarkup()}[/]";
-		string longPrefix = $"[{FlagStyle}]{settings.LongFlagPrefix.EscapeMarkup()}[/]";
-		string separator = $"{settings.FlagValueSeparators.First()}";
+		string shortPrefix = $"[{FlagStyle}]{context.Settings.ShortFlagPrefix.EscapeMarkup()}[/]";
+		string longPrefix = $"[{FlagStyle}]{context.Settings.LongFlagPrefix.EscapeMarkup()}[/]";
+		string separator = $"{context.Settings.FlagValueSeparators.First()}";
 
 		if (chained.Length > 0)
 		{
@@ -174,7 +328,7 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 		IRenderable container = GetContainer("Minimal example", markup);
 		items.Add(container);
 	}
-	private static void TryGetGroups(IReadOnlyDictionary<string, ICommandGroupInfo> groups, List<IRenderable> items)
+	private static void TryGetGroups(Context context, IReadOnlyDictionary<string, ICommandGroupInfo> groups, List<IRenderable> items)
 	{
 		if (groups.Count is 0)
 			return;
@@ -190,13 +344,15 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 
 		foreach (KeyValuePair<string, ICommandGroupInfo> group in groups)
 		{
-			Markup name = GetGroupName(group.Key);
-			Markup summary = GetDocumentation(group.Value.Documentation?.Summary);
+			GroupContext groupContext = new(context, group.Value);
+
+			Markup name = GetGroupName(groupContext, group.Value);
+			Markup summary = GetDocumentation(groupContext, group.Value.Documentation?.Summary);
 
 			table.AddRow(name, summary);
 		}
 	}
-	private static void TryGetCommands(IReadOnlyDictionary<string, ICommandInfo> commands, List<IRenderable> items)
+	private static void TryGetCommands(Context context, IReadOnlyDictionary<string, ICommandInfo> commands, List<IRenderable> items)
 	{
 		if (commands.Count is 0)
 			return;
@@ -212,13 +368,15 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 
 		foreach (KeyValuePair<string, ICommandInfo> command in commands)
 		{
-			Markup name = GetCommandName(command.Key);
-			Markup summary = GetDocumentation(command.Value.Documentation?.Summary);
+			CommandContext commandContext = new(context, command.Value);
+
+			Markup name = GetCommandName(context, command.Value);
+			Markup summary = GetDocumentation(commandContext, command.Value.Documentation?.Summary);
 
 			table.AddRow(name, summary);
 		}
 	}
-	private static void TryGetFlags(IEngineSettings settings, IReadOnlyCollection<IFlagInfo> flags, List<IRenderable> items)
+	private static void TryGetFlags(Context context, IReadOnlyCollection<IFlagInfo> flags, List<IRenderable> items)
 	{
 		if (flags.Count is 0)
 			return;
@@ -237,16 +395,16 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 
 		foreach (IFlagInfo flag in flags)
 		{
-			IRenderable shortName = GetShortFlag(settings, flag);
-			IRenderable longName = GetLongFlag(settings, flag);
+			IRenderable shortName = GetShortFlag(context, flag);
+			IRenderable longName = GetLongFlag(context, flag);
 			IRenderable isRequired = GetIsRequired(flag.ValueInfo.IsRequired);
 			IRenderable defaultValueLabel = GetDefaultLabel(flag.DefaultValueInfo);
-			IRenderable summary = GetDocumentation(flag.Documentation?.Summary);
+			IRenderable summary = GetDocumentation(context, flag.Documentation?.Summary);
 
 			table.AddRow(shortName, longName, isRequired, defaultValueLabel, summary);
 		}
 	}
-	private static void TryGetArguments(IReadOnlyList<IArgumentInfo> arguments, List<IRenderable> items)
+	private static void TryGetArguments(Context context, IReadOnlyList<IArgumentInfo> arguments, List<IRenderable> items)
 	{
 		if (arguments.Count is 0)
 			return;
@@ -264,10 +422,10 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 
 		foreach (IArgumentInfo argument in arguments)
 		{
-			IRenderable name = GetArgumentName(argument.Name);
+			IRenderable name = GetArgumentName(context, argument);
 			IRenderable isRequired = GetIsRequired(argument.ValueInfo.IsRequired);
 			IRenderable defaultValueLabel = GetDefaultLabel(argument.DefaultValueInfo);
-			IRenderable summary = GetDocumentation(argument.Documentation?.Summary);
+			IRenderable summary = GetDocumentation(context, argument.Documentation?.Summary);
 
 			table.AddRow(name, isRequired, defaultValueLabel, summary);
 		}
@@ -286,6 +444,7 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 
 		Rows rows = new(actualItems);
 		AnsiConsole.Write(rows);
+		AnsiConsole.WriteLine();
 	}
 	#endregion
 
@@ -323,28 +482,37 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 			return new("");
 
 		string escaped = info.Label.EscapeMarkup();
-		return new($"[{DefaultLabelStyle}]{escaped}[/]");
+		return new(escaped);
 	}
-	private static Markup GetArgumentName(string name)
+	private static Markup GetArgumentName(Context context, IArgumentInfo? argument)
 	{
-		string escaped = name.EscapeMarkup();
-		return new($"[{ArgumentStyle}]{escaped}[/]");
-	}
-	private static Markup GetCommandName(string? name)
-	{
-		if (name is null)
+		if (argument is null)
 			return new("");
 
-		string escaped = name.EscapeMarkup();
-		return new($"[{CommandStyle}]{escaped}[/]");
+		StringBuilder builder = new();
+		AddRawArgument(context, builder, argument);
+
+		return new(builder.ToString());
 	}
-	private static Markup GetGroupName(string? name)
+	private static Markup GetCommandName(Context context, ICommandInfo? command)
 	{
-		if (name is null)
+		if (command is null)
 			return new("");
 
-		string escaped = name.EscapeMarkup();
-		return new($"[{GroupStyle}]{escaped}[/]");
+		StringBuilder builder = new();
+		AddRawCommand(context, builder, command);
+
+		return new(builder.ToString());
+	}
+	private static Markup GetGroupName(Context context, ICommandGroupInfo? group)
+	{
+		if (group is null)
+			return new("");
+
+		StringBuilder builder = new();
+		AddRawGroup(context, builder, group);
+
+		return new(builder.ToString());
 	}
 	private static Markup GetIsRequired(bool isRequired)
 	{
@@ -353,43 +521,40 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 
 		return new($"[{OptionalStyle}]optional[/]");
 	}
-	private static Markup GetShortFlag(IEngineSettings settings, IFlagInfo flag)
+	private static Markup GetShortFlag(Context context, IFlagInfo flag)
 	{
-		if (flag.ShortName is null)
-			return new("");
+		StringBuilder builder = new();
+		AddRawShortFlag(context, builder, flag);
 
-		string prefix = settings.ShortFlagPrefix.EscapeMarkup();
-		string name = $"{flag.ShortName}".EscapeMarkup();
-
-		return new Markup($"[{FlagStyle}]{prefix}{name}[/]");
+		return new(builder.ToString());
 	}
-	private static Markup GetLongFlag(IEngineSettings settings, IFlagInfo flag)
+	private static Markup GetLongFlag(Context context, IFlagInfo flag)
 	{
-		if (flag.LongName is null)
-			return new("");
+		StringBuilder builder = new();
+		AddRawLongFlag(context, builder, flag);
 
-		string prefix = settings.LongFlagPrefix.EscapeMarkup();
-		string name = flag.LongName.EscapeMarkup();
-
-		return new Markup($"[{FlagStyle}]{prefix}{name}[/]");
+		return new(builder.ToString());
 	}
-	private static Markup GetDocumentation(IDocumentationNode? node)
+	private static Markup GetDocumentation(Context context, IDocumentationNode? node)
 	{
 		if (node is null)
 			return new("");
 
 		StringBuilder builder = new();
-		AddMarkupContent(builder, node);
+		AddMarkupContent(context, builder, node);
 
 		string content = builder.ToString();
 		return new(content);
 	}
-	private static void AddMarkupContent(StringBuilder builder, IEnumerable<IDocumentationNode> nodes)
+	#endregion
+
+	#region Raw markup helpers
+	private static void AddMarkupContent(Context context, StringBuilder builder, IEnumerable<IDocumentationNode> nodes)
 	{
 		foreach (IDocumentationNode node in nodes)
-			AddMarkupContent(builder, node);
+			AddMarkupContent(context, builder, node);
 	}
-	private static void AddMarkupContent(StringBuilder builder, IDocumentationNode? node)
+	private static void AddMarkupContent(Context context, StringBuilder builder, IDocumentationNode? node)
 	{
 		if (node is null)
 			return;
@@ -401,45 +566,177 @@ public sealed class DocumentationPrinter : IDocumentationPrinter
 		}
 		else if (node is ILineBreakTagDocumentationNode)
 			builder.AppendLine();
-		else if (node is ITagDocumentationNode nameRef && nameRef.NameReference is not null)
-		{
-			string escaped = nameRef.NameReference.EscapeMarkup();
-			builder.Append(escaped);
-		}
 		else if (node is IBoldTagDocumentationNode bold)
 		{
 			builder.Append("[bold]");
-			AddMarkupContent(builder, bold.Children);
+			AddMarkupContent(context, builder, bold.Children);
 			builder.Append("[/]");
 		}
 		else if (node is IItalicTagDocumentationNode italic)
 		{
 			builder.Append("[italic]");
-			AddMarkupContent(builder, italic.Children);
+			AddMarkupContent(context, builder, italic.Children);
 			builder.Append("[/]");
 		}
-		else if (node is ITagDocumentationNode link && link.Link is not null)
+		else if (node is ITagDocumentationNode tag)
 		{
-			if (link.Children.Count is 0)
+			if (tag.Link is not null)
 			{
-				builder
-					.Append("[link]")
-					.Append(link.Link.ToString().EscapeMarkup())
-					.Append("[/]");
+				if (tag.Children.Count is 0)
+				{
+					builder
+						.Append("[link]")
+						.Append(tag.Link.ToString().EscapeMarkup())
+						.Append("[/]");
+				}
+				else
+				{
+					builder
+						.Append("[link=")
+						.Append(tag.Link.ToString().EscapeMarkup())
+						.Append(']');
+
+					AddMarkupContent(context, builder, tag.Children);
+					builder.Append("[/]");
+				}
+			}
+			else if (tag.NameReference is not null)
+			{
+				AddRawReference(context, builder, tag.NameReference);
+				Debug.Assert(tag.Children.Count is 0);
+			}
+			else if (tag.CodeReference is not null)
+			{
+				AddRawReference(context, builder, tag.CodeReference);
+				Debug.Assert(tag.Children.Count is 0);
 			}
 			else
-			{
-				builder
-					.Append("[link=")
-					.Append(link.Link.ToString().EscapeMarkup())
-					.Append(']');
-
-				AddMarkupContent(builder, link.Children);
-				builder.Append("[/]");
-			}
+				AddMarkupContent(context, builder, tag.Children);
 		}
 		else if (node is IDocumentationNodeCollection collection)
-			AddMarkupContent(builder, collection.Children);
+			AddMarkupContent(context, builder, collection.Children);
+	}
+	private static void AddRawReference(Context context, StringBuilder builder, string id)
+	{
+		const string error = "[red]#error[/]";
+
+		if (FindTarget(context, id, out object? target) is false)
+		{
+			builder.Append(error);
+			return;
+		}
+
+		if (target is ICommandGroupInfo group && group.Name is not null)
+		{
+			AddRawParentChain(context, builder, group.Parent);
+			AddRawGroup(context, builder, group);
+
+			return;
+		}
+
+		if (target is ICommandInfo command && command.Name is not null)
+		{
+			AddRawParentChain(context, builder, command.Group);
+			AddRawCommand(context, builder, command);
+
+			return;
+		}
+
+		if (target is IFlagInfo flag)
+		{
+			AddRawFlag(context, builder, flag);
+			return;
+		}
+
+		if (target is IArgumentInfo argument)
+		{
+			AddRawArgument(context, builder, argument);
+			return;
+		}
+
+		builder.Append(error);
+	}
+	private static void AddRawGroup(Context context, StringBuilder builder, ICommandGroupInfo group)
+	{
+		if (group.Name is null)
+			return;
+
+		builder
+			.Append($"[{GroupStyle}]")
+			.Append(group.Name.EscapeMarkup())
+			.Append("[/]");
+	}
+	private static void AddRawCommand(Context context, StringBuilder builder, ICommandInfo command)
+	{
+		if (command.Name is null)
+			return;
+
+		builder
+			.Append($"[{CommandStyle}]")
+			.Append(command.Name.EscapeMarkup())
+			.Append("[/]");
+	}
+	private static void AddRawFlag(Context context, StringBuilder builder, IFlagInfo flag)
+	{
+		if (flag.LongName is not null)
+			AddRawLongFlag(context, builder, flag);
+		else
+			AddRawShortFlag(context, builder, flag);
+	}
+	private static void AddRawLongFlag(Context context, StringBuilder builder, IFlagInfo flag)
+	{
+		builder
+			.Append($"[{FlagStyle}]")
+			.Append(context.Settings.LongFlagPrefix)
+			.Append(flag.LongName.EscapeMarkup())
+			.Append("[/]");
+	}
+	private static void AddRawShortFlag(Context context, StringBuilder builder, IFlagInfo flag)
+	{
+		builder
+			.Append($"[{FlagStyle}]")
+			.Append(context.Settings.ShortFlagPrefix)
+			.Append(flag.ShortName.ToString().EscapeMarkup())
+			.Append("[/]");
+	}
+	private static void AddRawArgument(Context context, StringBuilder builder, IArgumentInfo argument)
+	{
+		builder
+			.Append($"[{ArgumentStyle}]")
+			.Append(argument.Name.EscapeMarkup())
+			.Append("[/]");
+	}
+	private static void AddRawParentChain(Context context, StringBuilder builder, ICommandGroupInfo? parent)
+	{
+		List<ICommandGroupInfo> parents = [];
+
+		while (parent?.Name is not null)
+		{
+			parents.Insert(0, parent);
+			parent = parent.Parent;
+		}
+
+		foreach (ICommandGroupInfo group in parents)
+		{
+			AddRawGroup(context, builder, group);
+			builder.Append(' ');
+		}
+	}
+	#endregion
+
+	#region Helpers
+	private static bool FindTarget(Context context, string key, [NotNullWhen(true)] out object? target)
+	{
+		if (context is CommandContext commandContext)
+		{
+			if (commandContext.Parameters.TryGetValue(key, out target))
+				return true;
+		}
+
+		if (context.Lookup.TryGetValue(key, out target))
+			return true;
+
+		return false;
 	}
 	#endregion
 }

--- a/src/CommandLine/Documentation/DocumentationProvider.cs
+++ b/src/CommandLine/Documentation/DocumentationProvider.cs
@@ -121,18 +121,17 @@ public sealed class DocumentationProvider : IDocumentationProvider
 				return null;
 
 			IDocumentationNode summary = new DocumentationNodeCollection(param.Children);
-			return new DocumentationInfo(summary, null);
+			return new DocumentationInfo(summary);
 		}
 
 		if (node is IDocumentationNodeCollection collection)
 		{
 			IDocumentationNode? summary = collection.Children.FirstOrDefault(c => c is ISummaryTagDocumentationNode);
-			if (summary is null)
-				return null;
-
 			IDocumentationNode? remarks = collection.Children.FirstOrDefault(c => c is IRemarksTagDocumentationNode);
+			IDocumentationNode? example = collection.Children.FirstOrDefault(c => c is IExampleTagDocumentationNode);
+			IDocumentationNode? returns = collection.Children.FirstOrDefault(c => c is IReturnsTagDocumentationNode);
 
-			return new DocumentationInfo(summary, remarks);
+			return new DocumentationInfo(summary, remarks, example, returns);
 		}
 
 		return null;

--- a/src/CommandLine/Engine/CommandEngineBuilder.cs
+++ b/src/CommandLine/Engine/CommandEngineBuilder.cs
@@ -402,7 +402,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 			return null;
 
 		TextDocumentationNode summary = new("Shows the help information about the available commands.");
-		DocumentationInfo documentation = new(summary, null);
+		DocumentationInfo documentation = new(summary);
 
 		IValueParser<bool> parser = SelectValueParser<bool>();
 		string label = GetDefaultValueLabel(settings, false);
@@ -421,7 +421,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 			return null;
 
 		TextDocumentationNode summary = new("Shows the help information about the available commands.");
-		DocumentationInfo documentation = new(summary, null);
+		DocumentationInfo documentation = new(summary);
 
 		return new VirtualCommandInfo(settings.HelpCommandName, null, [], [], documentation, false);
 	}
@@ -457,7 +457,7 @@ public sealed class CommandEngineBuilder : ICommandEngineBuilder
 			return null;
 
 		TextDocumentationNode summary = new("Shows the current version of the program.");
-		DocumentationInfo documentation = new(summary, null);
+		DocumentationInfo documentation = new(summary);
 
 		return new VirtualCommandInfo(settings.VersionCommandName, null, [], [], documentation, true);
 	}


### PR DESCRIPTION
This PR adds almost all of the extra documentation support as per issue #70.

__Features:__
- [x] Examples *(only one main example, no nested highlighting there, but that would be a very interesting feature - #86)*
- [x] Return value documentation.
- [x] Bold
- [x] Italic
- [x] Links
- [x] References *(technically partial, as only reference to know groups/commands/flags/arguments is allowed).*
- [ ] Lists
- [ ] Tables
- [ ] Code *(Shouldn't really be necessary)*

The missing features will probably *not* be implemented in this version, they will likely be left alone until the merge with the larger framework is done.